### PR TITLE
Add CPanel implementation

### DIFF
--- a/src/Data/CreateParams.php
+++ b/src/Data/CreateParams.php
@@ -14,6 +14,7 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
  * @property-read string|int|null $customer_identifier Service customer identifier, if already created
  * @property-read string|null $service_identifier Secondary service identifier to use, if known up-front
  * @property-read string|null $package_identifier Service package identifier, if any
+ * @property-read string|null $ip IP address
  * @property-read mixed[]|null $extra Any extra data to pass to the service endpoint
  */
 class CreateParams extends DataSet
@@ -27,6 +28,7 @@ class CreateParams extends DataSet
             'customer_identifier' => ['nullable'],
             'service_identifier' => ['nullable', 'string'],
             'package_identifier' => ['nullable', 'string'],
+            'ip' => ['nullable', 'ip'],
             'extra' => ['nullable', 'array'],
         ]);
     }

--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -9,6 +9,7 @@ use Upmind\ProvisionProviders\SoftwareLicenses\Providers\Generic\Provider as Gen
 use Upmind\ProvisionProviders\SoftwareLicenses\Providers\Example\Provider as ExampleProvider;
 use Upmind\ProvisionProviders\SoftwareLicenses\Providers\Blesta\Provider as BlestaProvider;
 use Upmind\ProvisionProviders\SoftwareLicenses\Providers\WHMCS\Provider as WHMCSProvider;
+use Upmind\ProvisionProviders\SoftwareLicenses\Providers\CPanel\Provider as CPanelProvider;
 
 class LaravelServiceProvider extends ProvisionServiceProvider
 {
@@ -21,5 +22,6 @@ class LaravelServiceProvider extends ProvisionServiceProvider
         $this->bindProvider('software-licenses', 'generic', GenericProvider::class);
         $this->bindProvider('software-licenses', 'blesta', BlestaProvider::class);
         $this->bindProvider('software-licenses', 'whmcs', WHMCSProvider::class);
+        $this->bindProvider('software-licenses', 'cpanel', CPanelProvider::class);
     }
 }

--- a/src/Providers/CPanel/Data/Configuration.php
+++ b/src/Providers/CPanel/Data/Configuration.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SoftwareLicenses\Providers\CPanel\Data;
+
+use Upmind\ProvisionBase\Provider\DataSet\DataSet;
+use Upmind\ProvisionBase\Provider\DataSet\Rules;
+
+/**
+ * CPanel licensing API configuration.
+ *
+ * @property-read string $username Username
+ * @property-read string $password Password
+ * @property-read integer|null $group_id Group ID
+ * @property-read bool|null $debug Whether or not to log api calls
+ */
+class Configuration extends DataSet
+{
+    public static function rules(): Rules
+    {
+        return new Rules([
+            'username' => ['required', 'string'],
+            'password' => ['required', 'string'],
+            'group_id' => ['nullable', 'integer'],
+            'debug' => ['nullable', 'boolean']
+        ]);
+    }
+}

--- a/src/Providers/CPanel/Provider.php
+++ b/src/Providers/CPanel/Provider.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SoftwareLicenses\Providers\CPanel;
+
+use GuzzleHttp\Client;
+use Throwable;
+use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
+use Upmind\ProvisionBase\Provider\DataSet\AboutData;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionProviders\SoftwareLicenses\Category;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\ChangePackageParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\ChangePackageResult;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\CreateParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\CreateResult;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\EmptyResult;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\GetUsageParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\GetUsageResult;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\ReissueParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\ReissueResult;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\SuspendParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\TerminateParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\UnsuspendParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Providers\CPanel\Data\Configuration;
+
+/**
+ * CPanel provider.
+ */
+class Provider extends Category implements ProviderInterface
+{
+    protected Configuration $configuration;
+    protected Client $client;
+
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function aboutProvider(): AboutData
+    {
+        return AboutData::create()
+            ->setName('CPanel')
+            ->setLogoUrl('https://api.upmind.io/images/logos/provision/cpanel-logo.png')
+            ->setDescription('Resell, provision and manage CPanel licenses');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getUsageData(GetUsageParams $params): GetUsageResult
+    {
+        return GetUsageResult::create()
+            ->setUsageData($this->getLicense($params->license_key));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function create(CreateParams $params): CreateResult
+    {
+        if (!isset($params->package_identifier)) {
+            throw $this->errorResult('Package identifier is required!');
+        }
+
+        try {
+            $command = 'XMLlicenseAdd';
+
+            $query = [
+                'packageid' => $params->package_identifier,
+                'ip' => $params->ip,
+            ];
+
+            if ($this->configuration->group_id) {
+                $query['groupid'] = $this->configuration->group_id;
+            }
+
+            $response = $this->makeRequest($command, $query);
+
+            return CreateResult::create(['license_key' => (string)$response['licenseid']])
+                ->setMessage('License created');
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * Get license data by key.
+     */
+    protected function getLicense(string $license_key): ?array
+    {
+        try {
+            $command = 'XMLlicenseInfo';
+
+            $query = [
+                "liscid" => $license_key,
+            ];
+
+            return (array)$this->makeRequest($command, $query);
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function changePackage(ChangePackageParams $params): ChangePackageResult
+    {
+        if (!isset($params->package_identifier)) {
+            throw $this->errorResult('Package identifier is required!');
+        }
+
+        try {
+            $command = 'XMLpackageUpdate';
+
+            $license = $this->getLicense($params->license_key);
+
+            $query = [
+                'ip' => $license['ip'],
+                'newpackageid' => $params->package_identifier
+            ];
+
+            $this->makeRequest($command, $query);
+
+            return ChangePackageResult::create()
+                ->setLicenseKey($params->license_key)
+                ->setPackageIdentifier($params->package_identifier)
+                ->setMessage('Package changed');
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function reissue(ReissueParams $params): ReissueResult
+    {
+        throw $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function suspend(SuspendParams $params): EmptyResult
+    {
+        throw $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function unsuspend(UnsuspendParams $params): EmptyResult
+    {
+        throw $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function terminate(TerminateParams $params): EmptyResult
+    {
+        try {
+            $command = "XMLlicenseExpire";
+
+            $query = [
+                'liscid' => $params->license_key,
+            ];
+
+            $this->makeRequest($command, $query);
+            return EmptyResult::create()->setMessage('License cancelled');
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    protected function client(): Client
+    {
+        if (isset($this->client)) {
+            return $this->client;
+        }
+
+        $credentials = base64_encode("{$this->configuration->username}:{$this->configuration->password}");
+
+        $client = new Client([
+            'base_uri' => 'https://manage2.cpanel.net',
+            'headers' => [
+                'Authorization' => ['Basic ' . $credentials],
+            ],
+            'connect_timeout' => 10,
+            'timeout' => 60,
+            'handler' => $this->getGuzzleHandlerStack(boolval($this->configuration->debug)),
+        ]);
+
+        return $this->client = $client;
+    }
+
+    /**
+     * @return no-return
+     * @throws Throwable
+     *
+     */
+    protected function handleException(Throwable $e): void
+    {
+        throw $e;
+    }
+
+    public function makeRequest(string $command, ?array $params = null, ?string $method = 'GET'): ?array
+    {
+        $requestParams = [
+            'query' => [],
+        ];
+
+        if ($params) {
+            $requestParams['query'] = $params;
+        }
+
+        $requestParams['query']['output'] = 'json';
+
+        $response = $this->client()->request($method, "/{$command}.cgi", $requestParams);
+        $result = $response->getBody()->getContents();
+
+        $response->getBody()->close();
+
+        if ($result === '') {
+            return null;
+        }
+
+        return $this->parseResponseData($result);
+    }
+
+    private function parseResponseData(string $result): ?array
+    {
+        $parsedResult = json_decode($result, true);
+
+        if (!$parsedResult && $parsedResult != []) {
+            throw ProvisionFunctionError::create('Unknown Provider API Error')
+                ->withData([
+                    'response' => $result,
+                ]);
+        }
+
+        if ($error = $this->getResponseErrorMessage($parsedResult)) {
+            throw ProvisionFunctionError::create($error)
+                ->withData([
+                    'response' => $parsedResult,
+                ]);
+        }
+
+        return $parsedResult;
+    }
+
+    protected function getResponseErrorMessage($responseData): ?string
+    {
+        $status = $responseData['status'] ?? null;
+
+        if ($status == 0) {
+            if (isset($responseData['reason']) && $responseData['reason'] == 'Empty license.') {
+                $errorMessage = 'License does not exist';
+            } else {
+                $errorMessage = $responseData['reason'] ?? null;
+            }
+        }
+
+        return $errorMessage ?? null;
+    }
+}


### PR DESCRIPTION
The following operations are implemented for CPanel:

- getUsageData() 
- create()
- changePackage()
- terminate()

The following operations aren't supported by CPanel:

- reissue() 
- suspend()
- unsuspend()