### PR TITLE
Add CPanel implementation - Updated

### DIFF
--- a/.docker/Dockerfile.example
+++ b/.docker/Dockerfile.example
@@ -1,6 +1,8 @@
 # Uncomment the php version that you want to test.
 # Currently the library is based on PHP 7.4.
-# FROM php:7.4-cli
+FROM php:7.4-cli
+
+# If using PHP v8.x, use any of the following images.
 # FROM php:8.0-cli
 # FROM php:8.1-cli
 # FROM php:8.2-cli

--- a/.docker/Dockerfile.example
+++ b/.docker/Dockerfile.example
@@ -1,0 +1,34 @@
+# Uncomment the php version that you want to test.
+# FROM php:7.4-cli
+# FROM php:8.0-cli
+# FROM php:8.1-cli
+# FROM php:8.2-cli
+
+# Install dependencies
+RUN apt update && \
+    apt upgrade -y && \
+    apt install -y \
+    git \
+    curl \
+    zip \
+    unzip
+
+# Install Packages via PECL as not provided by PHP Source
+RUN pecl install xdebug \
+	&& docker-php-ext-enable xdebug
+
+# For PHP 7.4 xdebug, uncomment & use the below instead
+# RUN pecl install xdebug-3.1.5 \
+# 	&& docker-php-ext-enable xdebug
+
+# Clear cache
+RUN apt clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install composer (get latest v2, change to `--1` if you want to install the latest v1).
+RUN curl -sS https://getcomposer.org/installer | php -- --2 --install-dir=/usr/local/bin --filename=composer
+
+COPY . /usr/src/lib
+WORKDIR /usr/src/lib
+
+CMD [ "php"]

--- a/.docker/Dockerfile.example
+++ b/.docker/Dockerfile.example
@@ -1,4 +1,5 @@
 # Uncomment the php version that you want to test.
+# Currently the library is based on PHP 7.4.
 # FROM php:7.4-cli
 # FROM php:8.0-cli
 # FROM php:8.1-cli
@@ -13,13 +14,13 @@ RUN apt update && \
     zip \
     unzip
 
-# Install Packages via PECL as not provided by PHP Source
-RUN pecl install xdebug \
-	&& docker-php-ext-enable xdebug
+# Install xdebug via PECL as not provided by PHP Source
+RUN pecl install xdebug-3.1.5 \
+    && docker-php-ext-enable xdebug
 
-# For PHP 7.4 xdebug, uncomment & use the below instead
-# RUN pecl install xdebug-3.1.5 \
-# 	&& docker-php-ext-enable xdebug
+# If using PHP 8.x, use the following to install xdebug. This is for future reference.
+# RUN pecl install xdebug \
+#     && docker-php-ext-enable xdebug
 
 # Clear cache
 RUN apt clean && \

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,20 @@
+# Composer
 /vendor/
 composer.lock
+
+# Tools
 .php-cs-fixer.cache
+
+# Docker
+docker-compose.yml
+.docker/Dockerfile
+
+# PHPUnit
+/tests/report/
+clover.xml
+phpunit.xml
+.phpunit.result.cache
+
+# IDE & System
+.idea/
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 All notable changes to the package will be documented in this file.
 
 ## [Unreleased]
-- Cpanel implementation
+
+- Implement Cpanel provider
 
 ## [v3.2](https://github.com/upmind-automation/provision-provider-software-licenses/releases/tag/v3.2) - 2023-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to the package will be documented in this file.
 
 ## [Unreleased]
 
-- Implement Cpanel provider
+- Implement cPanel provider
+- Added basic Unit Test functionality for cPanel Provider
+- Added docker examples to support automated testing
 
 ## [v3.2](https://github.com/upmind-automation/provision-provider-software-licenses/releases/tag/v3.2) - 2023-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the package will be documented in this file.
 
+## [Unreleased]
+- Cpanel implementation
+
 ## [v3.2](https://github.com/upmind-automation/provision-provider-software-licenses/releases/tag/v3.2) - 2023-06-16
 
 - Implement WHMCS provider

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 ## Credits
 
  - [Harry Lewis](https://github.com/uphlewis)
+ - [Ana Carrasco](https://github.com/AnaGema)
+ - [Roussetos Karafyllakis](https://github.com/RoussKS)
  - [All Contributors](../../contributors)
 
 ## License

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -48,8 +48,8 @@ These are the acceptance criteria for new providers.
 The project provides a basic docker example that will allow you to add & perform unit tests in isolation.
 
 1. You will need docker installed on your system & execute the following commands on the project's root on your terminal.
-2. Copy & rename `docker-compose.yml.example` tp `docker-compose.yml` -> `cp docker-compose.yml.example docker-compose.yml`
-3. Copy & rename `.docker/Dockerfile.example` tp `.docker/Dockerfile` -> `cp .docker/Dockerfile.example .docker/Dockerfile`
+2. Copy & rename `docker-compose.yml.example` to `docker-compose.yml` -> `cp docker-compose.yml.example docker-compose.yml`
+3. Copy & rename `.docker/Dockerfile.example` to `.docker/Dockerfile` -> `cp .docker/Dockerfile.example .docker/Dockerfile`
 4. Load the container -> `docker compose up -d`
 5. Enter the container -> `docker exec -it app /bin/bash`
 6. Install composer packages -> `composer install`

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -56,4 +56,4 @@ The project provides a basic docker example that will allow you to add & perform
 7. Run tests -> `./vendor/bin/phpunit`
 
 Currently, the project is using Laravel Validation rules and relies on the relevant Facade.
-As such, Unit Testing is not supported when the method triggers a `Dataset` object that includes validation rules.
+As a result, Unit Testing is not supported when the method triggers a `Dataset` object that includes validation rules.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -52,7 +52,8 @@ The project provides a basic docker example that will allow you to add & perform
 3. Copy & rename `.docker/Dockerfile.example` tp `.docker/Dockerfile` -> `cp .docker/Dockerfile.example .docker/Dockerfile`
 4. Load the container -> `docker compose up -d`
 5. Enter the container -> `docker exec -it app /bin/bash`
-6. Once inside the container `./vendor/phpunit/phpunit/phpunit`
+6. Install composer packages -> `composer install`
+7. Run tests -> `./vendor/bin/phpunit`
 
 Currently, the project is using Laravel Validation rules and relies on the relevant Facade.
 As such, Unit Testing is not supported when the method triggers a `Dataset` object that includes validation rules.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -42,3 +42,17 @@ These are the acceptance criteria for new providers.
 - Additional information or helpful metadata (e.g. raw API response data) should be returned in successful result debug or error data/debug
 - Any changes to `src/Category.php` or in `src/Data/` must be discussed with Upmind prior to the PR
 - Any new 3rd-party dependencies/libraries must be approved by Upmind
+
+## Testing
+
+The project provides a basic docker example that will allow you to add & perform unit tests.
+
+1. You will need docker installed on your system & execute the following commands on the project's root on your terminal.
+2. Copy & rename `docker-compose.yml.example` tp `docker-compose.yml` -> `cp docker-compose.yml.example docker-compose.yml`
+3. Copy & rename `.docker/Dockerfile.example` tp `.docker/Dockerfile` -> `cp .docker/Dockerfile.example .docker/Dockerfile`
+4. Load the container -> `docker compose up -d`
+5. Enter the container -> `docker exec -it app /bin/bash`
+6. Once inside the container `./vendor/phpunit/phpunit/phpunit`
+
+Currently, the project is using Laravel Validation rules and relies on the relevant Facade.
+As such, Unit Testing is not supported when the method triggers a `Dataset` object that includes validation rules.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -45,7 +45,7 @@ These are the acceptance criteria for new providers.
 
 ## Testing
 
-The project provides a basic docker example that will allow you to add & perform unit tests.
+The project provides a basic docker example that will allow you to add & perform unit tests in isolation.
 
 1. You will need docker installed on your system & execute the following commands on the project's root on your terminal.
 2. Copy & rename `docker-compose.yml.example` tp `docker-compose.yml` -> `cp docker-compose.yml.example docker-compose.yml`

--- a/composer.json
+++ b/composer.json
@@ -7,15 +7,30 @@
         {
             "name": "Harry Lewis",
             "email": "harry@upmind.com"
+        },
+        {
+            "name": "Roussetos Karafyllakis (RoussKS)",
+            "email": "roussetos@upmind.com"
         }
     ],
     "require": {
         "upmind/provision-provider-base": "^3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^8 || ^9 || ^10"
+    },
     "autoload": {
         "psr-4": {
             "Upmind\\ProvisionProviders\\SoftwareLicenses\\": "src/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Upmind\\ProvisionProviders\\SoftwareLicenses\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "sort-packages": true
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "upmind/provision-provider-base": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8 || ^9 || ^10"
+        "phpunit/phpunit": "^8 || ^9"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,10 @@
             "email": "harry@upmind.com"
         },
         {
+            "name": "Ana Carrasco",
+            "email": "ana.carrasco@upmind.com"
+        },
+        {
             "name": "Roussetos Karafyllakis (RoussKS)",
             "email": "roussetos@upmind.com"
         }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "upmind/provision-provider-base": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8 || ^9"
+        "phpunit/phpunit": "^8 || ^9",
+        "ext-json": "*"
     },
     "autoload": {
         "psr-4": {

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -1,0 +1,23 @@
+version: '3.3'
+services:
+  #PHP Service
+  app:
+    build:
+      context: .
+      dockerfile: ./.docker/Dockerfile
+    container_name: app
+    restart: unless-stopped
+    tty: true
+    environment:
+      SERVICE_NAME: app
+      SERVICE_TAGS: dev
+    working_dir: /usr/src/lib
+    volumes:
+      - ./:/usr/src/lib
+    networks:
+      - app-network
+
+#Docker Networks
+networks:
+  app-network:
+    driver: bridge

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="coverage-clover" target="clover.xml"/>
+    </logging>
+</phpunit>

--- a/src/Data/CreateParams.php
+++ b/src/Data/CreateParams.php
@@ -14,6 +14,7 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
  * @property-read string|int|null $customer_identifier Service customer identifier, if already created
  * @property-read string|null $service_identifier Secondary service identifier to use, if known up-front
  * @property-read string|null $package_identifier Service package identifier, if any
+ * @property-read string|null $ip IP address
  * @property-read mixed[]|null $extra Any extra data to pass to the service endpoint
  */
 class CreateParams extends DataSet
@@ -27,6 +28,7 @@ class CreateParams extends DataSet
             'customer_identifier' => ['nullable'],
             'service_identifier' => ['nullable', 'string'],
             'package_identifier' => ['nullable', 'string'],
+            'ip' => ['nullable', 'ip'],
             'extra' => ['nullable', 'array'],
         ]);
     }

--- a/src/Data/ReissueParams.php
+++ b/src/Data/ReissueParams.php
@@ -10,6 +10,7 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
 /**
  * @property-read mixed $license_key License key
  * @property-read string|int|null $customer_identifier Service customer identifier, if any
+ * @property-read string|null $ip IP address
  */
 class ReissueParams extends DataSet
 {
@@ -18,6 +19,7 @@ class ReissueParams extends DataSet
         return new Rules([
             'license_key' => ['required'],
             'customer_identifier' => ['nullable'],
+            'ip' => ['nullable', 'ip'],
         ]);
     }
 }

--- a/src/Data/ReissueParams.php
+++ b/src/Data/ReissueParams.php
@@ -10,7 +10,6 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
 /**
  * @property-read mixed $license_key License key
  * @property-read string|int|null $customer_identifier Service customer identifier, if any
- * @property-read string|null $ip IP address
  */
 class ReissueParams extends DataSet
 {
@@ -19,7 +18,6 @@ class ReissueParams extends DataSet
         return new Rules([
             'license_key' => ['required'],
             'customer_identifier' => ['nullable'],
-            'ip' => ['nullable', 'ip'],
         ]);
     }
 }

--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -9,6 +9,7 @@ use Upmind\ProvisionProviders\SoftwareLicenses\Providers\Generic\Provider as Gen
 use Upmind\ProvisionProviders\SoftwareLicenses\Providers\Example\Provider as ExampleProvider;
 use Upmind\ProvisionProviders\SoftwareLicenses\Providers\Blesta\Provider as BlestaProvider;
 use Upmind\ProvisionProviders\SoftwareLicenses\Providers\WHMCS\Provider as WHMCSProvider;
+use Upmind\ProvisionProviders\SoftwareLicenses\Providers\CPanel\Provider as CPanelProvider;
 
 class LaravelServiceProvider extends ProvisionServiceProvider
 {
@@ -21,5 +22,6 @@ class LaravelServiceProvider extends ProvisionServiceProvider
         $this->bindProvider('software-licenses', 'generic', GenericProvider::class);
         $this->bindProvider('software-licenses', 'blesta', BlestaProvider::class);
         $this->bindProvider('software-licenses', 'whmcs', WHMCSProvider::class);
+        $this->bindProvider('software-licenses', 'cpanel', CPanelProvider::class);
     }
 }

--- a/src/Providers/CPanel/Data/Configuration.php
+++ b/src/Providers/CPanel/Data/Configuration.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SoftwareLicenses\Providers\CPanel\Data;
+
+use Upmind\ProvisionBase\Provider\DataSet\DataSet;
+use Upmind\ProvisionBase\Provider\DataSet\Rules;
+
+/**
+ * CPanel licensing API configuration.
+ *
+ * @property-read string $username Username
+ * @property-read string $password Password
+ * @property-read integer|null $group_id Group ID
+ * @property-read bool|null $debug Whether or not to log api calls
+ */
+class Configuration extends DataSet
+{
+    public static function rules(): Rules
+    {
+        return new Rules([
+            'username' => ['required', 'string'],
+            'password' => ['required', 'string'],
+            'group_id' => ['nullable', 'integer'],
+            'debug' => ['nullable', 'boolean']
+        ]);
+    }
+}

--- a/src/Providers/CPanel/Provider.php
+++ b/src/Providers/CPanel/Provider.php
@@ -234,6 +234,7 @@ class Provider extends Category implements ProviderInterface
     {
         $requestParams = [
             'query' => [],
+            'http_errors' => false,
         ];
 
         if ($params) {

--- a/src/Providers/CPanel/Provider.php
+++ b/src/Providers/CPanel/Provider.php
@@ -306,12 +306,6 @@ class Provider extends Category implements ProviderInterface
 
         $licenseStatus = $licenseData['licenses']['L' . $licenseKey]['status'] ?? null;
 
-        /*
-         * A cPanel license can have different statuses where:
-         * 1 => Active
-         * 2 => Expired
-         * 4 => Suspended
-         */
         return $licenseStatus !== null && (int) $licenseStatus === 1;
     }
 

--- a/src/Providers/CPanel/Provider.php
+++ b/src/Providers/CPanel/Provider.php
@@ -64,7 +64,7 @@ class Provider extends Category implements ProviderInterface
     public function create(CreateParams $params): CreateResult
     {
         if (!isset($params->package_identifier)) {
-            throw $this->errorResult('Package identifier is required!');
+            $this->errorResult('Package identifier is required!');
         }
 
         try {
@@ -112,20 +112,18 @@ class Provider extends Category implements ProviderInterface
     public function changePackage(ChangePackageParams $params): ChangePackageResult
     {
         if (!isset($params->package_identifier)) {
-            throw $this->errorResult('Package identifier is required!');
+            $this->errorResult('Package identifier is required!');
         }
 
         try {
-            $command = 'XMLpackageUpdate';
-
-            $license = $this->getLicense($params->license_key);
+            $result = $this->getLicense($params->license_key);
 
             $query = [
-                'ip' => $license['ip'],
+                'ip' => $result['licenses']['L' . $params->license_key]['ip'] ?? null,
                 'newpackageid' => $params->package_identifier
             ];
 
-            $this->makeRequest($command, $query);
+            $this->makeRequest('XMLpackageUpdate', $query);
 
             return ChangePackageResult::create()
                 ->setLicenseKey($params->license_key)
@@ -141,7 +139,7 @@ class Provider extends Category implements ProviderInterface
      */
     public function reissue(ReissueParams $params): ReissueResult
     {
-        throw $this->errorResult('Operation not supported');
+        $this->errorResult('Operation not supported');
     }
 
     /**
@@ -149,7 +147,7 @@ class Provider extends Category implements ProviderInterface
      */
     public function suspend(SuspendParams $params): EmptyResult
     {
-        throw $this->errorResult('Operation not supported');
+        $this->errorResult('Operation not supported');
     }
 
     /**
@@ -157,7 +155,7 @@ class Provider extends Category implements ProviderInterface
      */
     public function unsuspend(UnsuspendParams $params): EmptyResult
     {
-        throw $this->errorResult('Operation not supported');
+        $this->errorResult('Operation not supported');
     }
 
     /**
@@ -166,13 +164,11 @@ class Provider extends Category implements ProviderInterface
     public function terminate(TerminateParams $params): EmptyResult
     {
         try {
-            $command = "XMLlicenseExpire";
-
             $query = [
                 'liscid' => $params->license_key,
             ];
 
-            $this->makeRequest($command, $query);
+            $this->makeRequest('XMLlicenseExpire', $query);
             return EmptyResult::create()->setMessage('License cancelled');
         } catch (\Throwable $e) {
             $this->handleException($e);

--- a/src/Providers/CPanel/Provider.php
+++ b/src/Providers/CPanel/Provider.php
@@ -119,10 +119,10 @@ class Provider extends Category implements ProviderInterface
         }
 
         try {
-            $result = $this->getLicense($params->license_key);
+            $licenseData = $this->getLicense($params->license_key);
 
             $query = [
-                'ip' => $result['licenses']['L' . $params->license_key]['ip'] ?? null,
+                'ip' => $licenseData['licenses']['L' . $params->license_key]['ip'] ?? null,
                 'newpackageid' => $params->package_identifier
             ];
 
@@ -189,6 +189,10 @@ class Provider extends Category implements ProviderInterface
      */
     public function terminate(TerminateParams $params): EmptyResult
     {
+        if (!$this->isLicenseActive($params->license_key)) {
+            return EmptyResult::create()->setMessage('License already cancelled');
+        }
+
         return $this->expireLicense($params->license_key);
     }
 
@@ -298,9 +302,9 @@ class Provider extends Category implements ProviderInterface
      */
     private function isLicenseActive(string $licenseKey): bool
     {
-        $result = $this->getLicense($licenseKey);
+        $licenseData = $this->getLicense($licenseKey);
 
-        $licenseStatus = $result['licenses']['L' . $licenseKey]['status'] ?? null;
+        $licenseStatus = $licenseData['licenses']['L' . $licenseKey]['status'] ?? null;
 
         /*
          * A cPanel license can have different statuses where:

--- a/src/Providers/CPanel/Provider.php
+++ b/src/Providers/CPanel/Provider.php
@@ -166,6 +166,10 @@ class Provider extends Category implements ProviderInterface
      */
     public function unsuspend(UnsuspendParams $params): EmptyResult
     {
+        if ($this->isLicenseActive($params->license_key)) {
+            return EmptyResult::create()->setMessage('License already active');
+        }
+
         try {
             $query = [
                 'liscid' => $params->license_key,
@@ -304,7 +308,7 @@ class Provider extends Category implements ProviderInterface
          * 2 => Expired
          * 4 => Suspended
          */
-        return (int) $licenseStatus === 1;
+        return $licenseStatus !== null && (int) $licenseStatus === 1;
     }
 
     /**

--- a/src/Providers/CPanel/Provider.php
+++ b/src/Providers/CPanel/Provider.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SoftwareLicenses\Providers\CPanel;
+
+use GuzzleHttp\Client;
+use Throwable;
+use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
+use Upmind\ProvisionBase\Provider\DataSet\AboutData;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionProviders\SoftwareLicenses\Category;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\ChangePackageParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\ChangePackageResult;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\CreateParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\CreateResult;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\EmptyResult;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\GetUsageParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\GetUsageResult;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\ReissueParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\ReissueResult;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\SuspendParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\TerminateParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\UnsuspendParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Providers\CPanel\Data\Configuration;
+
+/**
+ * CPanel provider.
+ */
+class Provider extends Category implements ProviderInterface
+{
+    protected Configuration $configuration;
+    protected Client $client;
+
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function aboutProvider(): AboutData
+    {
+        return AboutData::create()
+            ->setName('CPanel')
+            ->setLogoUrl('https://api.upmind.io/images/logos/provision/cpanel-logo.png')
+            ->setDescription('Resell, provision and manage CPanel licenses');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getUsageData(GetUsageParams $params): GetUsageResult
+    {
+        return GetUsageResult::create()
+            ->setUsageData($this->getLicense($params->license_key));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function create(CreateParams $params): CreateResult
+    {
+        if (!isset($params->package_identifier)) {
+            throw $this->errorResult('Package identifier is required!');
+        }
+
+        try {
+            $command = 'XMLlicenseAdd';
+
+            $query = [
+                'packageid' => $params->package_identifier,
+                'ip' => $params->ip,
+            ];
+
+            if ($this->configuration->group_id) {
+                $query['groupid'] = $this->configuration->group_id;
+            }
+
+            $response = $this->makeRequest($command, $query);
+
+            return CreateResult::create(['license_key' => (string)$response['licenseid']])
+                ->setMessage('License created');
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * Get license data by key.
+     */
+    protected function getLicense(string $license_key): ?array
+    {
+        try {
+            $command = 'XMLlicenseInfo';
+
+            $query = [
+                "liscid" => $license_key,
+            ];
+
+            return (array)$this->makeRequest($command, $query);
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function changePackage(ChangePackageParams $params): ChangePackageResult
+    {
+        if (!isset($params->package_identifier)) {
+            throw $this->errorResult('Package identifier is required!');
+        }
+
+        try {
+            $command = 'XMLpackageUpdate';
+
+            $license = $this->getLicense($params->license_key);
+
+            $query = [
+                'ip' => $license['ip'],
+                'newpackageid' => $params->package_identifier
+            ];
+
+            $this->makeRequest($command, $query);
+
+            return ChangePackageResult::create()
+                ->setLicenseKey($params->license_key)
+                ->setPackageIdentifier($params->package_identifier)
+                ->setMessage('Package changed');
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function reissue(ReissueParams $params): ReissueResult
+    {
+        throw $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function suspend(SuspendParams $params): EmptyResult
+    {
+        throw $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function unsuspend(UnsuspendParams $params): EmptyResult
+    {
+        throw $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function terminate(TerminateParams $params): EmptyResult
+    {
+        try {
+            $command = "XMLlicenseExpire";
+
+            $query = [
+                'liscid' => $params->license_key,
+            ];
+
+            $this->makeRequest($command, $query);
+            return EmptyResult::create()->setMessage('License cancelled');
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    protected function client(): Client
+    {
+        if (isset($this->client)) {
+            return $this->client;
+        }
+
+        $credentials = base64_encode("{$this->configuration->username}:{$this->configuration->password}");
+
+        $client = new Client([
+            'base_uri' => 'https://manage2.cpanel.net',
+            'headers' => [
+                'Authorization' => ['Basic ' . $credentials],
+            ],
+            'connect_timeout' => 10,
+            'timeout' => 60,
+            'handler' => $this->getGuzzleHandlerStack(boolval($this->configuration->debug)),
+        ]);
+
+        return $this->client = $client;
+    }
+
+    /**
+     * @return no-return
+     * @throws Throwable
+     *
+     */
+    protected function handleException(Throwable $e): void
+    {
+        throw $e;
+    }
+
+    public function makeRequest(string $command, ?array $params = null, ?string $method = 'GET'): ?array
+    {
+        $requestParams = [
+            'query' => [],
+        ];
+
+        if ($params) {
+            $requestParams['query'] = $params;
+        }
+
+        $requestParams['query']['output'] = 'json';
+
+        $response = $this->client()->request($method, "/{$command}.cgi", $requestParams);
+        $result = $response->getBody()->getContents();
+
+        $response->getBody()->close();
+
+        if ($result === '') {
+            return null;
+        }
+
+        return $this->parseResponseData($result);
+    }
+
+    private function parseResponseData(string $result): ?array
+    {
+        $parsedResult = json_decode($result, true);
+
+        if (!$parsedResult && $parsedResult != []) {
+            throw ProvisionFunctionError::create('Unknown Provider API Error')
+                ->withData([
+                    'response' => $result,
+                ]);
+        }
+
+        if ($error = $this->getResponseErrorMessage($parsedResult)) {
+            throw ProvisionFunctionError::create($error)
+                ->withData([
+                    'response' => $parsedResult,
+                ]);
+        }
+
+        return $parsedResult;
+    }
+
+    protected function getResponseErrorMessage($responseData): ?string
+    {
+        $status = $responseData['status'] ?? null;
+
+        if ($status == 0) {
+            if (isset($responseData['reason']) && $responseData['reason'] == 'Empty license.') {
+                $errorMessage = 'License does not exist';
+            } else {
+                $errorMessage = $responseData['reason'] ?? null;
+            }
+        }
+
+        return $errorMessage ?? null;
+    }
+}

--- a/src/Providers/CPanel/Provider.php
+++ b/src/Providers/CPanel/Provider.php
@@ -47,7 +47,7 @@ class Provider extends Category implements ProviderInterface
         return AboutData::create()
             ->setName('CPanel')
             ->setLogoUrl('https://api.upmind.io/images/logos/provision/cpanel-logo.png')
-            ->setDescription('Resell, provision and manage CPanel licenses');
+            ->setDescription('Resell, provision and manage cPanel licenses with manage2');
     }
 
     /**

--- a/src/Providers/CPanel/Provider.php
+++ b/src/Providers/CPanel/Provider.php
@@ -139,26 +139,10 @@ class Provider extends Category implements ProviderInterface
 
     /**
      * @inheritDoc
-     *
-     * @throws Throwable
      */
     public function reissue(ReissueParams $params): ReissueResult
     {
-        $licenseData = $this->getLicense($params->license_key);
-
-        try {
-            $query = [
-                'oldip' => $licenseData['licenses']['L' . $params->license_key]['ip'] ?? null,
-                'newip' => $params->ip,
-                'packageid' => $licenseData['licenses']['L' . $params->license_key]['packageid'] ?? null,
-            ];
-
-            $this->makeRequest('XMLtransfer', $query);
-
-            return ReissueResult::create(['license_key' => $params->license_key])->setMessage('License reissued');
-        } catch (Throwable $e) {
-            $this->handleException($e);
-        }
+        $this->errorResult('Operation not supported');
     }
 
     /**
@@ -296,7 +280,7 @@ class Provider extends Category implements ProviderInterface
         $status = $responseData['status'] ?? null;
 
         if ($status == 0) {
-            if (isset($responseData['reason']) && $responseData['reason'] === 'Empty license.') {
+            if (isset($responseData['reason']) && $responseData['reason'] == 'Empty license.') {
                 $errorMessage = 'License does not exist';
             } else {
                 $errorMessage = $responseData['reason'] ?? null;

--- a/tests/Unit/Providers/CPanel/ProviderTest.php
+++ b/tests/Unit/Providers/CPanel/ProviderTest.php
@@ -4,38 +4,98 @@ declare(strict_types=1);
 
 namespace Unit\Providers\CPanel;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
 use Upmind\ProvisionProviders\SoftwareLicenses\Data\ReissueParams;
-use Upmind\ProvisionProviders\SoftwareLicenses\Providers\CPanel\Data\Configuration;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\SuspendParams;
 use Upmind\ProvisionProviders\SoftwareLicenses\Providers\CPanel\Provider;
 
 class ProviderTest extends TestCase
 {
-    private ReissueParams $reissueParams;
+    /**
+     * @var Client|MockObject
+     */
+    private Client $client;
+
+    /**
+     * @var Provider|MockObject
+     */
     private Provider $provider;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->reissueParams = $this->createMock(ReissueParams::class);
+        $this->client = $this->createMock(Client::class);
 
-        $configuration = $this->createMock(Configuration::class);
-        $this->provider = new Provider($configuration);
+        $this->provider = $this->getMockBuilder(Provider::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['client'])
+            ->getMock();
+
+        $this->provider->method('client')->willReturn($this->client);
     }
 
     public function testReissueIsNotSupported(): void
     {
         $this->expectException(ProvisionFunctionError::class);
 
-        $this->provider->reissue($this->reissueParams);
+        $reissueParams = $this->createMock(ReissueParams::class);
+
+        $this->provider->reissue($reissueParams);
     }
 
     public function testReissueIsNotSupportedMessage(): void
     {
         $this->expectExceptionMessage('Operation not supported');
 
-        $this->provider->reissue($this->reissueParams);
+        $reissueParams = $this->createMock(ReissueParams::class);
+
+        $this->provider->reissue($reissueParams);
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    public function testCannotSuspendInactiveLicense(): void
+    {
+        $suspendParams = $this->createMock(SuspendParams::class);
+
+        $licenseKey = Str::random(6);
+
+        $suspendParams->expects($this->once())
+            ->method('__get')
+            ->with('license_key')
+            ->willReturn($licenseKey);
+
+        $responseData = [
+            'licenses' => [
+                'L' . $licenseKey => [
+                    'status' => $this->getInactiveLicenseStatus()
+                ]
+            ]
+        ];
+
+        $this->client->expects($this->once())->method('request')->willReturn(new Response(
+            200,
+            ['Content-Type' => 'application/json'],
+            json_encode($responseData, JSON_THROW_ON_ERROR)
+        ));
+
+        $result = $this->provider->suspend($suspendParams);
+
+        $this->assertSame('License already suspended', $result->getMessage());
+    }
+
+    /**
+     * Get a status that maps an inactive license.
+     */
+    private function getInactiveLicenseStatus(): int
+    {
+        return array_rand([2, 4]);
     }
 }

--- a/tests/Unit/Providers/CPanel/ProviderTest.php
+++ b/tests/Unit/Providers/CPanel/ProviderTest.php
@@ -133,6 +133,10 @@ class ProviderTest extends TestCase
     }
 
     /**
+     * The following test works because the result object `EmptyResult` does not have any validation rules.
+     * Otherwise, the test would fail as results with rules,
+     * rely on Laravel Facade Validator instance which cannot be instantiated on Unit Tests.
+     *
      * @throws \Throwable
      */
     public function testCannotSuspendInactiveLicense(): void

--- a/tests/Unit/Providers/CPanel/ProviderTest.php
+++ b/tests/Unit/Providers/CPanel/ProviderTest.php
@@ -91,39 +91,6 @@ class ProviderTest extends TestCase
     /**
      * @throws \Throwable
      */
-    public function testCannotSuspendInactiveLicense(): void
-    {
-        $suspendParams = $this->createMock(SuspendParams::class);
-
-        $licenseKey = Str::random(6);
-
-        $suspendParams->expects($this->once())
-            ->method('__get')
-            ->with('license_key')
-            ->willReturn($licenseKey);
-
-        $responseData = [
-            'licenses' => [
-                'L' . $licenseKey => [
-                    'status' => $this->inactiveLicenseStatus[array_rand($this->inactiveLicenseStatus)]
-                ]
-            ]
-        ];
-
-        $this->client->expects($this->once())->method('request')->willReturn(new Response(
-            200,
-            ['Content-Type' => 'application/json'],
-            json_encode($responseData, JSON_THROW_ON_ERROR)
-        ));
-
-        $result = $this->provider->suspend($suspendParams);
-
-        $this->assertSame('License already suspended', $result->getMessage());
-    }
-
-    /**
-     * @throws \Throwable
-     */
     public function testSuspendInactiveLicense(): void
     {
         $suspendParams = $this->createMock(SuspendParams::class);
@@ -163,5 +130,38 @@ class ProviderTest extends TestCase
         $result = $this->provider->suspend($suspendParams);
 
         $this->assertSame('License suspended', $result->getMessage());
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    public function testCannotSuspendInactiveLicense(): void
+    {
+        $suspendParams = $this->createMock(SuspendParams::class);
+
+        $licenseKey = Str::random(6);
+
+        $suspendParams->expects($this->once())
+            ->method('__get')
+            ->with('license_key')
+            ->willReturn($licenseKey);
+
+        $responseData = [
+            'licenses' => [
+                'L' . $licenseKey => [
+                    'status' => $this->inactiveLicenseStatus[array_rand($this->inactiveLicenseStatus)]
+                ]
+            ]
+        ];
+
+        $this->client->expects($this->once())->method('request')->willReturn(new Response(
+            200,
+            ['Content-Type' => 'application/json'],
+            json_encode($responseData, JSON_THROW_ON_ERROR)
+        ));
+
+        $result = $this->provider->suspend($suspendParams);
+
+        $this->assertSame('License already suspended', $result->getMessage());
     }
 }

--- a/tests/Unit/Providers/CPanel/ProviderTest.php
+++ b/tests/Unit/Providers/CPanel/ProviderTest.php
@@ -32,5 +32,10 @@ class ProviderTest extends TestCase
         $this->provider->reissue($this->reissueParams);
     }
 
+    public function testReissueIsNotSupportedMessage(): void
+    {
+        $this->expectExceptionMessage('Operation not supported');
 
+        $this->provider->reissue($this->reissueParams);
+    }
 }

--- a/tests/Unit/Providers/CPanel/ProviderTest.php
+++ b/tests/Unit/Providers/CPanel/ProviderTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Str;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\CreateParams;
 use Upmind\ProvisionProviders\SoftwareLicenses\Data\ReissueParams;
 use Upmind\ProvisionProviders\SoftwareLicenses\Data\SuspendParams;
 use Upmind\ProvisionProviders\SoftwareLicenses\Providers\CPanel\Provider;
@@ -49,6 +50,24 @@ class ProviderTest extends TestCase
             ->getMock();
 
         $this->provider->method('client')->willReturn($this->client);
+    }
+
+    public function testCannotCreateIfPackageIdentifierIsNotSet(): void
+    {
+        $this->expectException(ProvisionFunctionError::class);
+
+        $createParams = $this->createMock(CreateParams::class);
+
+        $this->provider->create($createParams);
+    }
+
+    public function testCannotCreateMessageIfPackageIdentifierIsNotSet(): void
+    {
+        $this->expectExceptionMessage('Package identifier is required!');
+
+        $createParams = $this->createMock(CreateParams::class);
+
+        $this->provider->create($createParams);
     }
 
     public function testReissueIsNotSupported(): void

--- a/tests/Unit/Providers/CPanel/ProviderTest.php
+++ b/tests/Unit/Providers/CPanel/ProviderTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\Providers\CPanel;
+
+use PHPUnit\Framework\TestCase;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\ReissueParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Providers\CPanel\Data\Configuration;
+use Upmind\ProvisionProviders\SoftwareLicenses\Providers\CPanel\Provider;
+
+class ProviderTest extends TestCase
+{
+    private ReissueParams $reissueParams;
+    private Provider $provider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->reissueParams = $this->createMock(ReissueParams::class);
+
+        $configuration = $this->createMock(Configuration::class);
+        $this->provider = new Provider($configuration);
+    }
+
+    public function testReissueIsNotSupported(): void
+    {
+        $this->expectException(ProvisionFunctionError::class);
+
+        $this->provider->reissue($this->reissueParams);
+    }
+
+
+}

--- a/tests/Unit/Providers/CPanel/ProviderTest.php
+++ b/tests/Unit/Providers/CPanel/ProviderTest.php
@@ -129,7 +129,7 @@ class ProviderTest extends TestCase
 
         $result = $this->provider->suspend($suspendParams);
 
-        $this->assertSame('License suspended', $result->getMessage());
+        $this->assertEquals('License suspended', $result->getMessage());
     }
 
     /**
@@ -162,6 +162,6 @@ class ProviderTest extends TestCase
 
         $result = $this->provider->suspend($suspendParams);
 
-        $this->assertSame('License already suspended', $result->getMessage());
+        $this->assertEquals('License already suspended', $result->getMessage());
     }
 }


### PR DESCRIPTION
Referencing #8 ,  added some amendments for changePackage method.

The following operations are implemented for CPanel:

- `getUsageData()` -> uses [List License Information](https://docs.cpanel.net/manage2/api/manage2-api-list-license-information/)
- `create()` -> [Add Licenses](https://docs.cpanel.net/manage2/api/manage2-api-add-licenses/)
- `changePackage()` -> [Change a License Package](https://docs.cpanel.net/manage2/api/manage2-api-change-a-license-package/)
- `terminate()` -> [Expire Licenses](https://docs.cpanel.net/manage2/api/manage2-api-expire-licenses/)
- `suspend()` -> [Expire Licenses](https://docs.cpanel.net/manage2/api/manage2-api-expire-licenses/)
- `unsuspend()` -> [Re-activate Expired license](https://docs.cpanel.net/manage2/api/manage2-api-reactivate-expired-licenses/)

The following operations aren't supported by CPanel:

- `reissue()` - There was not a corresponding API method to use.


The following items have been added as part of the PR
- Base docker setup for Unit Testing
- Simple Unit testing of some of the Provider methods
  - Unit testing requests that return a `Dataset` with non-empty rules will fail, as they rely on Laravel Validator facade (errors with `RuntimeException: A facade root has not been set.`)
- Updated Workflow documentation for test setup