### PR TITLE
Generic Provider return types & terminate method

### DIFF
--- a/src/Providers/Generic/Provider.php
+++ b/src/Providers/Generic/Provider.php
@@ -119,7 +119,7 @@ class Provider extends Category implements ProviderInterface
      */
     public function reissue(ReissueParams $params): ReissueResult
     {
-        if (!$this->configuration->has_usage_data) {
+        if (!$this->configuration->has_reissue) {
             $this->errorResult('Reissuance of this license is not possible');
         }
 

--- a/src/Providers/Generic/Provider.php
+++ b/src/Providers/Generic/Provider.php
@@ -101,8 +101,8 @@ class Provider extends Category implements ProviderInterface
             $this->errorResult('No usage data endpoint set in this configuration');
         }
 
-        $method = strtoupper($this->configuration->create_endpoint_http_method);
-        $endpointUrl = $this->configuration->create_endpoint_url;
+        $method = strtoupper($this->configuration->get_usage_data_endpoint_http_method);
+        $endpointUrl = $this->configuration->get_usage_data_endpoint_url;
 
         $requestParams = $params->toArray();
         $requestParams = array_merge($requestParams, Arr::pull($requestParams, 'extra', [])); // merge extra params

--- a/src/Providers/Generic/Provider.php
+++ b/src/Providers/Generic/Provider.php
@@ -225,7 +225,7 @@ class Provider extends Category implements ProviderInterface
     {
         return new Client([
             RequestOptions::HTTP_ERRORS => false,
-            'handler' => $this->getGuzzleHandlerStack(!!$this->configuration->debug),
+            'handler' => $this->getGuzzleHandlerStack((bool) $this->configuration->debug),
         ]);
     }
 }

--- a/src/Providers/Generic/Provider.php
+++ b/src/Providers/Generic/Provider.php
@@ -76,7 +76,7 @@ class Provider extends Category implements ProviderInterface
     public function changePackage(ChangePackageParams $params): ChangePackageResult
     {
         if (!$this->configuration->has_change_package) {
-            return $this->errorResult('No change package endpoint set in this configuration');
+            $this->errorResult('No change package endpoint set in this configuration');
         }
 
         $method = strtoupper($this->configuration->change_package_endpoint_http_method);
@@ -98,7 +98,7 @@ class Provider extends Category implements ProviderInterface
     public function getUsageData(GetUsageParams $params): GetUsageResult
     {
         if (!$this->configuration->has_usage_data) {
-            return $this->errorResult('No usage data endpoint set in this configuration');
+            $this->errorResult('No usage data endpoint set in this configuration');
         }
 
         $method = strtoupper($this->configuration->create_endpoint_http_method);
@@ -120,7 +120,7 @@ class Provider extends Category implements ProviderInterface
     public function reissue(ReissueParams $params): ReissueResult
     {
         if (!$this->configuration->has_usage_data) {
-            return $this->errorResult('Reissuance of this license is not possible');
+            $this->errorResult('Reissuance of this license is not possible');
         }
 
         $method = strtoupper($this->configuration->reissue_endpoint_http_method);
@@ -138,7 +138,7 @@ class Provider extends Category implements ProviderInterface
     public function suspend(SuspendParams $params): EmptyResult
     {
         if (!$this->configuration->has_suspension) {
-            return $this->errorResult('No suspend endpoint set in this configuration');
+            $this->errorResult('No suspend endpoint set in this configuration');
         }
 
         $method = strtoupper($this->configuration->suspend_endpoint_http_method);
@@ -159,7 +159,7 @@ class Provider extends Category implements ProviderInterface
     public function unsuspend(UnsuspendParams $params): EmptyResult
     {
         if (!$this->configuration->has_suspension) {
-            return $this->errorResult('No unsuspend endpoint set in this configuration');
+            $this->errorResult('No unsuspend endpoint set in this configuration');
         }
 
         $method = strtoupper($this->configuration->unsuspend_endpoint_http_method);
@@ -180,7 +180,7 @@ class Provider extends Category implements ProviderInterface
     public function terminate(TerminateParams $params): EmptyResult
     {
         if (!$this->configuration->has_terminate) {
-            return $this->errorResult('No terminate endpoint set in this configuration');
+            $this->errorResult('No terminate endpoint set in this configuration');
         }
 
         $method = strtoupper($this->configuration->terminate_endpoint_http_method);

--- a/src/Providers/Generic/Provider.php
+++ b/src/Providers/Generic/Provider.php
@@ -179,7 +179,7 @@ class Provider extends Category implements ProviderInterface
      */
     public function terminate(TerminateParams $params): EmptyResult
     {
-        if (!$this->configuration->has_terminate) {
+        if (!$this->configuration->has_termination) {
             $this->errorResult('No terminate endpoint set in this configuration');
         }
 

--- a/src/Providers/Generic/Provider.php
+++ b/src/Providers/Generic/Provider.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Upmind\ProvisionProviders\SoftwareLicenses\Providers\Generic;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
+use Psr\Http\Message\ResponseInterface;
 use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
 use Upmind\ProvisionBase\Provider\DataSet\AboutData;
 use Upmind\ProvisionProviders\SoftwareLicenses\Category;
@@ -195,7 +195,7 @@ class Provider extends Category implements ProviderInterface
         return EmptyResult::create();
     }
 
-    protected function request(string $method, string $uri, array $requestParams): Response
+    protected function request(string $method, string $uri, array $requestParams): ResponseInterface
     {
         return $this->client()->request($method, $uri, $this->getRequestOptions($method, $requestParams));
     }

--- a/src/Providers/Generic/Provider.php
+++ b/src/Providers/Generic/Provider.php
@@ -10,7 +10,6 @@ use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
 use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
 use Upmind\ProvisionBase\Provider\DataSet\AboutData;
-use Upmind\ProvisionBase\Provider\DataSet\ResultData;
 use Upmind\ProvisionProviders\SoftwareLicenses\Category;
 use Upmind\ProvisionProviders\SoftwareLicenses\Data\ChangePackageParams;
 use Upmind\ProvisionProviders\SoftwareLicenses\Data\ChangePackageResult;
@@ -151,7 +150,7 @@ class Provider extends Category implements ProviderInterface
         $handler = new DefaultResponseHandler($this->request($method, $endpointUrl, $requestParams));
         $handler->assertResponseSuccess();
 
-        return ResultData::create();
+        return EmptyResult::create();
     }
 
     /**
@@ -172,7 +171,7 @@ class Provider extends Category implements ProviderInterface
         $handler = new DefaultResponseHandler($this->request($method, $endpointUrl, $requestParams));
         $handler->assertResponseSuccess();
 
-        return ResultData::create();
+        return EmptyResult::create();
     }
 
     /**
@@ -193,7 +192,7 @@ class Provider extends Category implements ProviderInterface
         $handler = new DefaultResponseHandler($this->request($method, $endpointUrl, $requestParams));
         $handler->assertResponseSuccess();
 
-        return ResultData::create();
+        return EmptyResult::create();
     }
 
     protected function request(string $method, string $uri, array $requestParams): Response


### PR DESCRIPTION
Closes #11 - Fix return type to be EmptyResult instead of ResultData
Closes #13 - Fix terminate method to check for `has_termination` as set in the `Configuration` properties
Closes #15 - Fix reissue config enabled check & usage data config endpoints/method

Minor changes
- `errorResult` method throws an exception, so there is no need to return a value. Removed `return`
- Return ResponseInterface as expected from method call