### PR TITLE
Pax8 Implementation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
     name: 'PHP Unit'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         php: [ 7.4, 8.1, 8.2, 8.3 ]
     steps:

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ start-containers:
 	docker compose up -d --build
 
 # Stop the dev environment
-stop-containers:
+stop-containers: --prep-docker-compose-file
 	docker compose down
 
 # Stop and remove all containers

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The following providers are currently implemented:
   - [WHMCS](https://assets.whmcs.com/reseller/api/whmcs-reseller-api-docs-v3.2.pdf)
   - [cPanel](https://docs.cpanel.net/manage2/api/)
   - [IspManager](https://www.ispmanager.com/docs/for-partners/reselling-of-ispmanager-licenses-via-api)
+  - [Pax8](https://devx.pax8.com/reference/createaccesstoken)
 
 ## Functions
 

--- a/composer.json
+++ b/composer.json
@@ -39,9 +39,11 @@
     },
     "config": {
         "audit": {
-            "ignore": {
-                "PKSA-wws7-mr54-jsny": "Applies for Windoes systems, not in use by the library"
-            }
+            "ignore": [
+                "CVE-2024-51736",
+                "CVE-2025-64500",
+                "CVE-2024-50345"
+            ]
         },
         "sort-packages": true
     },

--- a/composer.json
+++ b/composer.json
@@ -40,9 +40,10 @@
     "config": {
         "audit": {
             "ignore": [
+                "CVE-2024-50345",
                 "CVE-2024-51736",
                 "CVE-2025-64500",
-                "CVE-2024-50345"
+                "CVE-2026-24739"
             ]
         },
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,11 @@
         }
     },
     "config": {
+        "audit": {
+            "ignore": {
+                "PKSA-wws7-mr54-jsny": "Applies for Windoes systems, not in use by the library"
+            }
+        },
         "sort-packages": true
     },
     "extra": {

--- a/src/Data/CreateParams.php
+++ b/src/Data/CreateParams.php
@@ -10,6 +10,8 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
 /**
  * @property-read string $customer_name Name of the customer
  * @property-read string $customer_email Email address of the customer
+ * @property-read string|null $customer_phone Phone number of the customer in international format
+ * @property-read CustomerAddressParams|null $customer_address Address of the customer
  * @property-read string|null $company_name Company name of the customer
  * @property-read string|int|null $customer_identifier Service customer identifier, if already created
  * @property-read string|null $service_identifier Secondary service identifier to use, if known up-front
@@ -25,6 +27,8 @@ class CreateParams extends DataSet
         return new Rules([
             'customer_name' => ['required', 'string'],
             'customer_email' => ['required', 'email'],
+            'customer_phone' => ['nullable', 'string', 'international_phone'],
+            'customer_address' => ['nullable', CustomerAddressParams::class],
             'company_name' => ['nullable', 'string'],
             'customer_identifier' => ['nullable'],
             'service_identifier' => ['nullable', 'string'],

--- a/src/Data/CustomerAddressParams.php
+++ b/src/Data/CustomerAddressParams.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SoftwareLicenses\Data;
+
+use Upmind\ProvisionBase\Provider\DataSet\DataSet;
+use Upmind\ProvisionBase\Provider\DataSet\Rules;
+
+/**
+ * Data representing a customer address.
+ *
+ * @property-read string|null $address_1 First line of the address
+ * @property-read string|null $address_2 Second line of the address
+ * @property-read string|null $city City of the address
+ * @property-read string|null $state State/region of the address
+ * @property-read string|null $postcode Postal code of the address
+ * @property-read string|null $country_code ISO 3166-1 alpha-2 country code
+ */
+class CustomerAddressParams extends DataSet
+{
+    public static function rules(): Rules
+    {
+        return new Rules([
+            'address_1' => ['nullable', 'string'],
+            'address_2' => ['nullable', 'string'],
+            'city' => ['nullable', 'string'],
+            'state' => ['nullable', 'string'],
+            'postcode' => ['nullable', 'string'],
+            'country_code' => ['nullable', 'country_code'],
+        ]);
+    }
+}

--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -10,6 +10,7 @@ use Upmind\ProvisionProviders\SoftwareLicenses\Providers\Example\Provider as Exa
 use Upmind\ProvisionProviders\SoftwareLicenses\Providers\Blesta\Provider as BlestaProvider;
 use Upmind\ProvisionProviders\SoftwareLicenses\Providers\WHMCS\Provider as WHMCSProvider;
 use Upmind\ProvisionProviders\SoftwareLicenses\Providers\CPanel\Provider as CPanelProvider;
+use Upmind\ProvisionProviders\SoftwareLicenses\Providers\Pax8\Provider as Pax8Provider;
 
 class LaravelServiceProvider extends ProvisionServiceProvider
 {
@@ -23,5 +24,6 @@ class LaravelServiceProvider extends ProvisionServiceProvider
         $this->bindProvider('software-licenses', 'blesta', BlestaProvider::class);
         $this->bindProvider('software-licenses', 'whmcs', WHMCSProvider::class);
         $this->bindProvider('software-licenses', 'cpanel', CPanelProvider::class);
+        $this->bindProvider('software-licenses', 'pax8', Pax8Provider::class);
     }
 }

--- a/src/Providers/Pax8/Data/Configuration.php
+++ b/src/Providers/Pax8/Data/Configuration.php
@@ -10,16 +10,16 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
 /**
  * Pax8 licensing API configuration.
  *
- * @property-read string $clientId Client ID
- * @property-read string $clientSecret Client Secret
+ * @property-read string $client_id Client ID
+ * @property-read string $client_secret Client Secret
  */
 class Configuration extends DataSet
 {
     public static function rules(): Rules
     {
         return new Rules([
-            'clientId' => ['required', 'string'],
-            'clientSecret' => ['required', 'string'],
+            'client_id' => ['required', 'string'],
+            'client_secret' => ['required', 'string'],
         ]);
     }
 }

--- a/src/Providers/Pax8/Data/Configuration.php
+++ b/src/Providers/Pax8/Data/Configuration.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SoftwareLicenses\Providers\Pax8\Data;
+
+use Upmind\ProvisionBase\Provider\DataSet\DataSet;
+use Upmind\ProvisionBase\Provider\DataSet\Rules;
+
+/**
+ * Pax8 licensing API configuration.
+ *
+ * @property-read string $clientId Client ID
+ * @property-read string $clientSecret Client Secret
+ */
+class Configuration extends DataSet
+{
+    public static function rules(): Rules
+    {
+        return new Rules([
+            'clientId' => ['required', 'string'],
+            'clientSecret' => ['required', 'string'],
+        ]);
+    }
+}

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\ServerException;
+use JsonException;
 use RuntimeException;
 use Throwable;
 use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
@@ -531,16 +532,13 @@ class Provider extends Category implements ProviderInterface
      */
     private function parseResponseData(string $result): array
     {
-        $parsedResult = json_decode($result, true);
-
-        if (!$parsedResult && $parsedResult !== []) {
-            throw ProvisionFunctionError::create('Unknown Provider API Error')
-                ->withData([
-                    'response' => $result,
-                ]);
+        try {
+            return json_decode($result, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $ex) {
+            $this->errorResult('Unknown Provider API Error', [
+                'response' => $result
+            ], [], $ex);
         }
-
-        return $parsedResult;
     }
 
 

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -113,7 +113,7 @@ class Provider extends Category implements ProviderInterface
                 $billingTerm = '3-Year';
                 break;
             default:
-                $this->errorResult('Invalid billing cycle months!', [
+                $this->errorResult('Invalid billing cycle months!', [], [
                     'billing_cycle_months' => $params->billing_cycle_months,
                     'allowed_billing_cycle_months' => [null, 1, 12, 24, 36]
                 ]);
@@ -133,11 +133,9 @@ class Provider extends Category implements ProviderInterface
             $company = $this->getCompanyById($params->customer_identifier);
 
             if (!$company['id']) {
-                $this->errorResult(
-                    'Company not found',
-                    [],
-                    ['customer_identifier' => $params->customer_identifier]
-                );
+                $this->errorResult('Company not found', [], [
+                    'customer_identifier' => $params->customer_identifier
+                ]);
             }
 
             $companyId = (string) $company['id'];

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -294,12 +294,13 @@ class Provider extends Category implements ProviderInterface
      */
     public function unsuspend(UnsuspendParams $params): EmptyResult
     {
-        if ($this->isLicenseInProgress($params->license_key)) {
-            $this->errorResult('License cannot be suspended while a Provisioning task is in progress');
-        }
-
+        // First check if license is already active, no need for further action.
         if ($this->isLicenseActive($params->license_key)) {
             return EmptyResult::create()->setMessage('License already active');
+        }
+
+        if ($this->isLicenseInProgress($params->license_key)) {
+            $this->errorResult('License cannot be unsuspended while a Provisioning task is in progress');
         }
 
         return $this->unsuspendSubscription($params->license_key);

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -628,6 +628,8 @@ class Provider extends Category implements ProviderInterface
                 }
             }
         }
+
+        return null;
     }
 
     /**
@@ -713,6 +715,7 @@ class Provider extends Category implements ProviderInterface
     private function createContacts(string $customer_name, string $customer_email, string $companyId, string $phone): void
     {
         @[$firstName, $lastName] = explode(' ', $customer_name, 2);
+
 
         $contactBody = [
             'firstName' => $firstName,

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Upmind\ProvisionProviders\SoftwareLicenses\Providers\Pax8;
 
-use DateTime;
+use DateTimeImmutable;
+use DateTimeZone;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
@@ -622,7 +623,7 @@ class Provider extends Category implements ProviderInterface
      */
     private function unsuspendSubscription(string $subscriptionId, string $message = 'License unsuspended'): EmptyResult
     {
-        $date = new DateTime('now', 'UTC');
+        $date = new DateTimeImmutable('now', new DateTimeZone('UTC'));
 
         $body = [
             'startDate' => $date->format('Y-m-d\TH:i:s.v')

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -19,6 +19,7 @@ use Upmind\ProvisionProviders\SoftwareLicenses\Data\ChangePackageParams;
 use Upmind\ProvisionProviders\SoftwareLicenses\Data\ChangePackageResult;
 use Upmind\ProvisionProviders\SoftwareLicenses\Data\CreateParams;
 use Upmind\ProvisionProviders\SoftwareLicenses\Data\CreateResult;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\CustomerAddressParams;
 use Upmind\ProvisionProviders\SoftwareLicenses\Data\EmptyResult;
 use Upmind\ProvisionProviders\SoftwareLicenses\Data\GetUsageParams;
 use Upmind\ProvisionProviders\SoftwareLicenses\Data\GetUsageResult;
@@ -118,38 +119,55 @@ class Provider extends Category implements ProviderInterface
                 ]);
         }
 
+        // First validate that either we have a customer identifier, or both address and service identifier.
+        if (empty($params->customer_identifier)
+            && (empty($params->customer_address) || empty($params->service_identifier))
+        ) {
+            $this->errorResult(
+                'Either Customer identifier or Customer address & Service identifier (company website) are required'
+            );
+        }
+
+        // First try to get company by customer identifier, if not found, continue to create a new one.
         try {
-            $companyId = null;
+            $company = $this->getCompanyById($params->customer_identifier);
 
-            if (!empty($params->customer_name)) {
-                $companyId = $this->getCompanyByName($params->customer_name);
-            }
-
-            if (!$companyId && !empty($params->company_name)) {
-                $company = $this->getCompanyById($params->company_name);
-                if ($company) {
-                    $companyId = $params->company_name;
-                }
-            }
-
-            if (!$companyId) {
-                if (!(isset($params->extra['address']))) {
-                    $this->errorResult('Extra.address is required!');
-                }
-
-                $phone = $params->extra['phone'] ?? '00000000';
-
-                $address = $params->extra['address'];
-
-                $companyId = $this->createCompany(
-                    $params->customer_name,
-                    $params->customer_email,
-                    $address,
-                    $params->customer_identifier,
-                    $phone
+            if (!$company['id']) {
+                $this->errorResult(
+                    'Company not found',
+                    [],
+                    ['customer_identifier' => $params->customer_identifier]
                 );
             }
 
+            $companyId = (string) $company['id'];
+        } catch (ClientException $ex) {
+            // If error other than not found, rethrow
+            if ($ex->getResponse()->getStatusCode() !== 404) {
+                $this->handleException($ex);
+            }
+
+            throw $ex;
+        } catch (Throwable $t) {
+            $this->handleException($t);
+        }
+
+        // If company not found, create a new one
+        if (!isset($companyId)) {
+            try {
+                $companyId = $this->createCompany(
+                    $params->customer_name,
+                    $params->customer_email,
+                    $params->customer_address,
+                    $params->service_identifier,
+                    $params->customer_phone ?? '00000000'
+                );
+            } catch (Throwable $e) {
+                $this->handleException($e);
+            }
+        }
+
+        try {
             $lineItem = [
                 'productId' => $productId,
                 'billingTerm' => $billingTerm,
@@ -180,14 +198,19 @@ class Provider extends Category implements ProviderInterface
 
             $licenseId = null;
             $response = $this->makeRequest('orders', ['isMock' => 'false'], $body);
+
             foreach ($response['lineItems'] as $lineItem) {
-                if ($lineItem['productId'] == $productId) {
+                if ((string) $lineItem['productId'] === $productId) {
                     $licenseId = $lineItem['subscriptionId'];
                 }
             }
 
-            return CreateResult::create(['license_key' => (string)$licenseId])
-                ->setMessage('License created');
+            return CreateResult::create([
+                'license_key' => (string) $licenseId,
+                'service_identifier' => $params->service_identifier,
+                'package_identifier' => $productId,
+                'customer_identifier' => $companyId,
+            ])->setMessage('License created');
         } catch (Throwable $e) {
             $this->handleException($e);
         }
@@ -612,35 +635,6 @@ class Provider extends Category implements ProviderInterface
     }
 
     /**
-     * @param string $customer
-     * @return string|null
-     * @throws GuzzleException
-     */
-    private function getCompanyByName(string $customer): ?string
-    {
-        $query = [
-            'size' => 200,
-        ];
-
-        for ($page = 0; ; $page++) {
-            $query['page'] = $page;
-
-            $response = $this->makeRequest('companies', $query, null, 'GET');
-            if (!isset($response['content'])) {
-                return null;
-            }
-
-            foreach ($response['content'] as $company) {
-                if ($company['name'] === $customer) {
-                    return $company['id'];
-                }
-            }
-        }
-
-        return null;
-    }
-
-    /**
      * @param string $companyId
      * @return array
      * @throws GuzzleException
@@ -648,7 +642,8 @@ class Provider extends Category implements ProviderInterface
     private function getCompanyById(string $companyId): array
     {
         $response = $this->makeRequest("companies/{$companyId}", null, null, 'GET');
-        return (array)$response;
+
+        return (array) $response;
     }
 
     /**
@@ -711,11 +706,12 @@ class Provider extends Category implements ProviderInterface
 
     /**
      * @throws GuzzleException
+     * @throws ProvisionFunctionError
      */
     private function createCompany(
         string $customer_name,
         string $customer_email,
-        array $address,
+        CustomerAddressParams $address,
         string $website,
         string $phone
     ): string {
@@ -730,11 +726,16 @@ class Provider extends Category implements ProviderInterface
         ];
 
         $response = $this->makeRequest('companies', null, $body);
-        $companyId = $response['id'];
+
+        if (!isset($response['id'])) {
+            $this->errorResult('Unable to create company');
+        }
+
+        $companyId = (string) $response['id'];
 
         $this->createContacts($customer_name, $customer_email, $companyId, $phone);
 
-        return (string)$companyId;
+        return $companyId;
     }
 
     /**
@@ -752,7 +753,7 @@ class Provider extends Category implements ProviderInterface
 
         $contactBody = [
             'firstName' => $firstName,
-            'lastName' => $lastName != "" ? $lastName : $firstName,
+            'lastName' => $lastName !== '' ? $lastName : $firstName,
             'email' => $customer_email,
             'phone' => $phone,
             'types' => [

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -40,6 +40,7 @@ class Provider extends Category implements ProviderInterface
     protected Configuration $configuration;
     protected ?Client $client = null;
     protected ?string $token = null;
+    private ?string $customerDomainPrefix = null;
 
     public function __construct(Configuration $configuration)
     {
@@ -119,60 +120,59 @@ class Provider extends Category implements ProviderInterface
                 ]);
         }
 
-        // First validate that either we have a customer identifier, or both address and service identifier.
-        if (empty($params->customer_identifier)
-            && (empty($params->customer_address) || empty($params->service_identifier))
-        ) {
+        // First validate that either we have a customer identifier, or a customer address.
+        if (empty($params->customer_identifier) && empty($params->customer_address)) {
             $this->errorResult(
-                'Either Customer identifier or Customer address & Service identifier (company website) are required'
+                'Either Customer identifier or Customer address is required'
             );
         }
 
-        // First try to get company by customer identifier, if not found, continue to create a new one.
-        try {
-            $company = $this->getCompanyById($params->customer_identifier);
+        // If customer identifier is provided, try to get the company
+        if (!empty($params->customer_identifier)) {
+            try {
+                $company = $this->getCompanyById($params->customer_identifier);
 
-            if (!$company['id']) {
-                $this->errorResult('Company not found', [], [
-                    'customer_identifier' => $params->customer_identifier
-                ]);
+                $companyId = (string) $company['id'];
+
+                // Now build provisioning details for existing customer.
+                $provisioningDetails = $this->buildProvisioningDetails($params, null, true);
+            } catch (Throwable $t) {
+                $this->handleException($t);
             }
+        } else {
+            // If not an existing company, create it.
 
-            $companyId = (string) $company['id'];
-        } catch (ClientException $ex) {
-            // If error other than not found, rethrow, otherwise continue to create a new company.
-            if ($ex->getResponse()->getStatusCode() !== 404) {
-                $this->handleException($ex);
-            }
-        } catch (Throwable $t) {
-            $this->handleException($t);
-        }
+            // Use phone library to handle in local format.
+            $customerPhone = $params->customer_phone !== null ? phone($params->customer_phone) : '00000000';
 
-        // If company not found, create a new one
-        if (!isset($companyId)) {
             try {
                 $companyId = $this->createCompany(
                     $params->customer_name,
                     $params->customer_email,
                     $params->customer_address,
-                    $params->service_identifier,
-                    $params->customer_phone ?? '00000000'
+                    $params->service_identifier ?? $this->getCustomerDomainPrefix(),
+                    is_string($customerPhone) ? $customerPhone : $customerPhone->formatNational()
                 );
+
+                // Now build provisioning details for new customer.
+                $provisioningDetails = $this->buildProvisioningDetails($params, $this->getCustomerDomainPrefix());
             } catch (Throwable $e) {
                 $this->handleException($e);
             }
         }
 
         // Now create the order to fetch the license.
-        try {
-            $lineItem = [
-                'productId' => $productId,
-                'billingTerm' => $billingTerm,
-                'lineItemNumber' => 1,
-                'quantity' => 1,
-            ];
+        $lineItem = [
+            'productId' => $productId,
+            'billingTerm' => $billingTerm,
+            'lineItemNumber' => 1,
+            'quantity' => 1,
+            'provisioningDetails' => $provisioningDetails,
+        ];
 
+        try {
             $dependency = $this->getProductDependencies($productId, $lineItem['billingTerm']);
+
             if ($dependency) {
                 $lineItem['commitmentTermId'] = $dependency['id'];
                 $lineItem['billingTerm'] = $dependency['term'];
@@ -181,8 +181,6 @@ class Provider extends Category implements ProviderInterface
             if ($lineItem['billingTerm'] === '1-Year') {
                 $lineItem['billingTerm'] = 'Annual';
             }
-
-            $lineItem['provisioningDetails'] = $this->buildProvisioningDetails($params);
 
             $body = [
                 'companyId' => $companyId,
@@ -208,7 +206,6 @@ class Provider extends Category implements ProviderInterface
 
             if (!isset($licenseId)) {
                 $this->errorResult('Unable to create license', [], [
-                    'service_identifier' => $params->service_identifier,
                     'package_identifier' => $productId,
                     'customer_identifier' => $companyId,
                 ]);
@@ -216,7 +213,6 @@ class Provider extends Category implements ProviderInterface
 
             return CreateResult::create([
                 'license_key' => (string) $licenseId,
-                'service_identifier' => $params->service_identifier,
                 'package_identifier' => $productId,
                 'customer_identifier' => $companyId,
             ])->setMessage('License created');
@@ -352,7 +348,7 @@ class Provider extends Category implements ProviderInterface
         }
 
         $response = $this->client()->request($method, "/v1/{$command}", $requestParams);
-        $result = $response->getBody()->getContents();
+        $result = $response->getBody()->__toString();
 
         $response->getBody()->close();
 
@@ -446,19 +442,23 @@ class Provider extends Category implements ProviderInterface
         return $response['access_token'];
     }
 
-    /**
-     * @param CreateParams $params
-     * @return array
-     */
-    private function buildProvisioningDetails(CreateParams $params): array
-    {
+    private function buildProvisioningDetails(
+        CreateParams $params,
+        ?string $domainPrefix,
+        bool $existingCustomer = false
+    ): array {
         $sharedDetails = $this->getSharedMicrosoftDetails();
 
-        if (isset($params->customer_identifier)) {
+        if ($existingCustomer) {
             $details = $this->getExistingCustomerDetails($params->customer_identifier);
         } else {
             @[$firstName, $lastName] = explode(' ', $params->customer_name, 2);
-            $details = $this->getNewCustomerDetails($firstName, $lastName, $params->customer_email ?? '');
+            $details = $this->getNewCustomerDetails(
+                $firstName,
+                $lastName,
+                $params->customer_email,
+                $domainPrefix ?? $this->getCustomerDomainPrefix(),
+            );
         }
 
         $details = array_merge($details, $sharedDetails);
@@ -467,12 +467,9 @@ class Provider extends Category implements ProviderInterface
     }
 
     /**
-     * @param string $firstName
-     * @param string $lastName
-     * @param string $email
      * @return string[]
      */
-    private function getNewCustomerDetails(string $firstName, string $lastName, string $email): array
+    private function getNewCustomerDetails(string $firstName, string $lastName, string $email, string $domain): array
     {
         return [
             'msCustExists' => 'No, the customer does not have a Microsoft account',
@@ -482,6 +479,7 @@ class Provider extends Category implements ProviderInterface
             'msftContactFirstName' => $firstName,
             'msftContactLastName' => $lastName,
             'msftContactEmail' => $email,
+            'msDomain' => $domain,
         ];
     }
 
@@ -494,11 +492,9 @@ class Provider extends Category implements ProviderInterface
         return [
             'msCustExists' => 'Yes, the customer has and can log into their Microsoft account',
             'msTenantId' => $tenantId,
-
             'mca2020FirstName' => '',
             'mca2020LastName' => '',
             'mca2020Email' => '',
-
             'msftContactFirstName' => '',
             'msftContactLastName' => '',
             'msftContactEmail' => '',
@@ -518,11 +514,6 @@ class Provider extends Category implements ProviderInterface
         ];
     }
 
-
-    /**
-     * @param array $details
-     * @return array
-     */
     private function formatProvisioningDetails(array $details): array
     {
         return array_map(
@@ -542,7 +533,7 @@ class Provider extends Category implements ProviderInterface
     {
         $parsedResult = json_decode($result, true);
 
-        if (!$parsedResult && $parsedResult != []) {
+        if (!$parsedResult && $parsedResult !== []) {
             throw ProvisionFunctionError::create('Unknown Provider API Error')
                 ->withData([
                     'response' => $result,
@@ -766,7 +757,6 @@ class Provider extends Category implements ProviderInterface
     {
         @[$firstName, $lastName] = explode(' ', $customer_name, 2);
 
-
         $contactBody = [
             'firstName' => $firstName,
             'lastName' => $lastName !== '' ? $lastName : $firstName,
@@ -800,7 +790,8 @@ class Provider extends Category implements ProviderInterface
     private function getProductDependencies(string $productId, string $billingTerm): ?array
     {
         $response = $this->makeRequest("products/{$productId}/dependencies", null, null, 'GET');
-        if (!$response['commitmentDependencies']) {
+
+        if (!isset($response['commitmentDependencies'])) {
             return null;
         }
 
@@ -811,5 +802,17 @@ class Provider extends Category implements ProviderInterface
         }
 
         return $response['commitmentDependencies'][0];
+    }
+
+    /**
+     * Get a generated unique domain prefix for the customer.
+     */
+    private function getCustomerDomainPrefix(): string
+    {
+        if ($this->customerDomainPrefix === null) {
+            $this->customerDomainPrefix = bin2hex(random_bytes(8));
+        }
+
+        return $this->customerDomainPrefix;
     }
 }

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -529,7 +529,7 @@ class Provider extends Category implements ProviderInterface
     /**
      * @throws ProvisionFunctionError
      */
-    private function parseResponseData(string $result): ?array
+    private function parseResponseData(string $result): array
     {
         $parsedResult = json_decode($result, true);
 

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -248,11 +248,7 @@ class Provider extends Category implements ProviderInterface
     }
 
     /**
-     * @inheritDoc
-     *
-     * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws ProvisionFunctionError
-     * @throws \Throwable
      */
     public function changePackage(ChangePackageParams $params): ChangePackageResult
     {
@@ -260,8 +256,6 @@ class Provider extends Category implements ProviderInterface
     }
 
     /**
-     * @inheritDoc
-     *
      * @throws ProvisionFunctionError
      */
     public function reissue(ReissueParams $params): ReissueResult

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -140,12 +140,10 @@ class Provider extends Category implements ProviderInterface
 
             $companyId = (string) $company['id'];
         } catch (ClientException $ex) {
-            // If error other than not found, rethrow
+            // If error other than not found, rethrow, otherwise continue to create a new company.
             if ($ex->getResponse()->getStatusCode() !== 404) {
                 $this->handleException($ex);
             }
-
-            throw $ex;
         } catch (Throwable $t) {
             $this->handleException($t);
         }

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -201,6 +201,11 @@ class Provider extends Category implements ProviderInterface
                 if (isset($lineItem['productId']) && (string) $lineItem['productId'] === $productId) {
                     $licenseId = $lineItem['subscriptionId'] ?? null;
                 }
+
+                // Break early if we have found the license ID
+                if (isset($licenseId)) {
+                    break;
+                }
             }
 
             if (!isset($licenseId)) {

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -167,6 +167,7 @@ class Provider extends Category implements ProviderInterface
             }
         }
 
+        // Now create the order to fetch the license.
         try {
             $lineItem = [
                 'productId' => $productId,
@@ -196,13 +197,20 @@ class Provider extends Category implements ProviderInterface
                 ],
             ];
 
-            $licenseId = null;
             $response = $this->makeRequest('orders', ['isMock' => 'false'], $body);
 
             foreach ($response['lineItems'] as $lineItem) {
                 if ((string) $lineItem['productId'] === $productId) {
                     $licenseId = $lineItem['subscriptionId'];
                 }
+            }
+
+            if (!isset($licenseId)) {
+                $this->errorResult('Unable to create license', [], [
+                    'service_identifier' => $params->service_identifier,
+                    'package_identifier' => $productId,
+                    'customer_identifier' => $companyId,
+                ]);
             }
 
             return CreateResult::create([
@@ -465,11 +473,9 @@ class Provider extends Category implements ProviderInterface
     {
         return [
             'msCustExists' => 'No, the customer does not have a Microsoft account',
-
             'mca2020FirstName' => $firstName,
             'mca2020LastName' => $lastName,
             'mca2020Email' => $email,
-
             'msftContactFirstName' => $firstName,
             'msftContactLastName' => $lastName,
             'msftContactEmail' => $email,
@@ -783,14 +789,13 @@ class Provider extends Category implements ProviderInterface
      */
     private function getProductDependencies(string $productId, string $billingTerm): ?array
     {
-
         $response = $this->makeRequest("products/{$productId}/dependencies", null, null, 'GET');
         if (!$response['commitmentDependencies']) {
             return null;
         }
 
         foreach ($response['commitmentDependencies'] as $dependency) {
-            if ($dependency['term'] == $billingTerm) {
+            if ((string) $dependency['term'] === $billingTerm) {
                 return $dependency;
             }
         }

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -39,7 +39,6 @@ class Provider extends Category implements ProviderInterface
     protected Configuration $configuration;
     protected ?Client $client = null;
 
-
     protected ?string $token = null;
 
     public function __construct(Configuration $configuration)
@@ -150,7 +149,7 @@ class Provider extends Category implements ProviderInterface
                 $lineItem['billingTerm'] = $dependency['term'];
             }
 
-            if ($lineItem['billingTerm'] == '1-Year') {
+            if ($lineItem['billingTerm'] === '1-Year') {
                 $lineItem['billingTerm'] = 'Annual';
             }
 
@@ -180,102 +179,6 @@ class Provider extends Category implements ProviderInterface
         }
     }
 
-
-    /**
-     * @param CreateParams $params
-     * @return array
-     */
-    function buildProvisioningDetails(CreateParams $params): array
-    {
-        $sharedDetails = $this->getSharedMicrosoftDetails();
-
-        if (isset($params->customer_identifier)) {
-            $details = $this->getExistingCustomerDetails($params->customer_identifier);
-        } else {
-            @[$firstName, $lastName] = explode(' ', $params->customer_name, 2);
-            $details = $this->getNewCustomerDetails($firstName, $lastName, $params->customer_email ?? '');
-        }
-
-        $details = array_merge($details, $sharedDetails);
-
-        return $this->formatProvisioningDetails($details);
-    }
-
-    /**
-     * @param string $firstName
-     * @param string $lastName
-     * @param string $email
-     * @return string[]
-     */
-    function getNewCustomerDetails(
-        string $firstName,
-        string $lastName,
-        string $email
-    ): array
-    {
-        return [
-            'msCustExists' => 'No, the customer does not have a Microsoft account',
-
-            'mca2020FirstName' => $firstName,
-            'mca2020LastName' => $lastName,
-            'mca2020Email' => $email,
-
-            'msftContactFirstName' => $firstName,
-            'msftContactLastName' => $lastName,
-            'msftContactEmail' => $email,
-        ];
-    }
-
-    /**
-     * @param string $tenantId
-     * @return string[]
-     */
-    function getExistingCustomerDetails(string $tenantId): array
-    {
-        return [
-            'msCustExists' => 'Yes, the customer has and can log into their Microsoft account',
-            'msTenantId' => $tenantId,
-
-            'mca2020FirstName' => '',
-            'mca2020LastName' => '',
-            'mca2020Email' => '',
-
-            'msftContactFirstName' => '',
-            'msftContactLastName' => '',
-            'msftContactEmail' => '',
-        ];
-    }
-
-    /**
-     * @return string[]
-     */
-    function getSharedMicrosoftDetails(): array
-    {
-        return [
-            'microsoftCancelPolicyAcknowledgement' =>
-                'I understand, and acknowledge that I will have a 7 calendar day window to cancel my subscription, or make quantity decrements before I am no longer able to make these changes. Once a subscription is locked, I will be required fulfill my elected commitment term of my subscription.',
-            'microsoftTrialConversion' =>
-                'I understand and acknowledge that at the conclusion of my Microsoft trial license period (30 days), my 25 trial subscriptions will automatically convert to 25 paid subscriptions.'
-        ];
-    }
-
-
-    /**
-     * @param array $details
-     * @return array
-     */
-    function formatProvisioningDetails(array $details): array
-    {
-        return array_map(
-            fn($key, $value) => [
-                'key' => $key,
-                'values' => $value !== '' ? [$value] : [],
-            ],
-            array_keys($details),
-            $details
-        );
-    }
-
     /**
      * @param RenewParams $params
      * @return RenewResult
@@ -289,24 +192,6 @@ class Provider extends Category implements ProviderInterface
             ->setLicenseKey($params->license_key)
             ->setPackageIdentifier($params->package_identifier)
             ->setMessage('Renewal not required for Pax8 licenses');
-    }
-
-    /**
-     * Get license data by key.
-     *
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     * @throws ProvisionFunctionError
-     * @throws \Throwable
-     */
-    protected function getSubscription(string $license_key): ?array
-    {
-        try {
-            $response = $this->makeRequest("subscriptions/{$license_key}", null, null, 'GET');
-            return (array)$response;
-
-        } catch (Throwable $e) {
-            $this->handleException($e);
-        }
     }
 
     /**
@@ -392,71 +277,6 @@ class Provider extends Category implements ProviderInterface
         return $this->cancelSubscription($params->license_key);
     }
 
-    protected function client(): Client
-    {
-        if (isset($this->client)) {
-            return $this->client;
-        }
-
-        $client = new Client([
-            'base_uri' => 'https://api.pax8.com',
-            'connect_timeout' => 10,
-            'headers' => [
-                'accept' => 'application/json',
-                'content-type' => 'application/json',
-            ],
-            'timeout' => 60,
-            'handler' => $this->getGuzzleHandlerStack(),
-        ]);
-
-        return $this->client = $client;
-    }
-
-    /**
-     * @throws ProvisionFunctionError
-     * @throws RuntimeException
-     */
-    private function getAuthToken(): string
-    {
-        $body = [
-            'client_id' => $this->configuration->clientId,
-            'client_secret' => $this->configuration->clientSecret,
-            'audience' => 'https://api.pax8.com',
-            'grant_type' => 'client_credentials',
-        ];
-
-        $response = $this->makeRequest('token', null, $body);
-
-        return $response['access_token'];
-    }
-
-    /**
-     * @return no-return
-     * @throws \Throwable
-     *
-     */
-    protected function handleException(Throwable $e): void
-    {
-        if (($e instanceof ClientException || $e instanceof ServerException) && $e->hasResponse()) {
-            /** @var \Psr\Http\Message\ResponseInterface $response */
-            $response = $e->getResponse();
-
-            $responseBody = $response->getBody()->__toString();
-            $responseData = json_decode($responseBody, true);
-
-            $errorMessage = $responseData['message'] ?? null;
-
-            $this->errorResult(
-                sprintf('Provider API Error: %s', $errorMessage),
-                ['response_data' => $responseData],
-                [],
-                $e
-            );
-        }
-
-        throw $e;
-    }
-
     /**
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws ProvisionFunctionError
@@ -493,6 +313,180 @@ class Provider extends Category implements ProviderInterface
         }
 
         return $this->parseResponseData($result);
+    }
+
+    /**
+     * @return no-return
+     * @throws \Throwable
+     *
+     */
+    protected function handleException(Throwable $e): void
+    {
+        if (($e instanceof ClientException || $e instanceof ServerException) && $e->hasResponse()) {
+            /** @var \Psr\Http\Message\ResponseInterface $response */
+            $response = $e->getResponse();
+
+            $responseBody = $response->getBody()->__toString();
+            $responseData = json_decode($responseBody, true);
+
+            $errorMessage = $responseData['message'] ?? null;
+
+            $this->errorResult(
+                sprintf('Provider API Error: %s', $errorMessage),
+                ['response_data' => $responseData],
+                [],
+                $e
+            );
+        }
+
+        throw $e;
+    }
+
+    protected function client(): Client
+    {
+        if (isset($this->client)) {
+            return $this->client;
+        }
+
+        $client = new Client([
+            'base_uri' => 'https://api.pax8.com',
+            'connect_timeout' => 10,
+            'headers' => [
+                'accept' => 'application/json',
+                'content-type' => 'application/json',
+            ],
+            'timeout' => 60,
+            'handler' => $this->getGuzzleHandlerStack(),
+        ]);
+
+        return $this->client = $client;
+    }
+
+    /**
+     * Get license data by key.
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws ProvisionFunctionError
+     * @throws \Throwable
+     */
+    protected function getSubscription(string $license_key): ?array
+    {
+        try {
+            $response = $this->makeRequest("subscriptions/{$license_key}", null, null, 'GET');
+            return (array)$response;
+
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @throws ProvisionFunctionError
+     * @throws RuntimeException
+     */
+    private function getAuthToken(): string
+    {
+        $body = [
+            'client_id' => $this->configuration->client_id,
+            'client_secret' => $this->configuration->client_secret,
+            'audience' => 'https://api.pax8.com',
+            'grant_type' => 'client_credentials',
+        ];
+
+        $response = $this->makeRequest('token', null, $body);
+
+        return $response['access_token'];
+    }
+
+    /**
+     * @param CreateParams $params
+     * @return array
+     */
+    private function buildProvisioningDetails(CreateParams $params): array
+    {
+        $sharedDetails = $this->getSharedMicrosoftDetails();
+
+        if (isset($params->customer_identifier)) {
+            $details = $this->getExistingCustomerDetails($params->customer_identifier);
+        } else {
+            @[$firstName, $lastName] = explode(' ', $params->customer_name, 2);
+            $details = $this->getNewCustomerDetails($firstName, $lastName, $params->customer_email ?? '');
+        }
+
+        $details = array_merge($details, $sharedDetails);
+
+        return $this->formatProvisioningDetails($details);
+    }
+
+    /**
+     * @param string $firstName
+     * @param string $lastName
+     * @param string $email
+     * @return string[]
+     */
+    private function getNewCustomerDetails(string $firstName, string $lastName, string $email): array
+    {
+        return [
+            'msCustExists' => 'No, the customer does not have a Microsoft account',
+
+            'mca2020FirstName' => $firstName,
+            'mca2020LastName' => $lastName,
+            'mca2020Email' => $email,
+
+            'msftContactFirstName' => $firstName,
+            'msftContactLastName' => $lastName,
+            'msftContactEmail' => $email,
+        ];
+    }
+
+    /**
+     * @param string $tenantId
+     * @return string[]
+     */
+    private function getExistingCustomerDetails(string $tenantId): array
+    {
+        return [
+            'msCustExists' => 'Yes, the customer has and can log into their Microsoft account',
+            'msTenantId' => $tenantId,
+
+            'mca2020FirstName' => '',
+            'mca2020LastName' => '',
+            'mca2020Email' => '',
+
+            'msftContactFirstName' => '',
+            'msftContactLastName' => '',
+            'msftContactEmail' => '',
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getSharedMicrosoftDetails(): array
+    {
+        return [
+            'microsoftCancelPolicyAcknowledgement' =>
+                'I understand, and acknowledge that I will have a 7 calendar day window to cancel my subscription, or make quantity decrements before I am no longer able to make these changes. Once a subscription is locked, I will be required fulfill my elected commitment term of my subscription.',
+            'microsoftTrialConversion' =>
+                'I understand and acknowledge that at the conclusion of my Microsoft trial license period (30 days), my 25 trial subscriptions will automatically convert to 25 paid subscriptions.'
+        ];
+    }
+
+
+    /**
+     * @param array $details
+     * @return array
+     */
+    private function formatProvisioningDetails(array $details): array
+    {
+        return array_map(
+            fn($key, $value) => [
+                'key' => $key,
+                'values' => $value !== '' ? [$value] : [],
+            ],
+            array_keys($details),
+            $details
+        );
     }
 
     /**

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -97,6 +97,27 @@ class Provider extends Category implements ProviderInterface
             $this->errorResult('Cannot find package!');
         }
 
+        switch ($params->billing_cycle_months) {
+            case null:
+            case 1:
+                $billingTerm = 'Monthly';
+                break;
+            case 12:
+                $billingTerm = 'Annual';
+                break;
+            case 24:
+                $billingTerm = '2-Year';
+                break;
+            case 36:
+                $billingTerm = '3-Year';
+                break;
+            default:
+                $this->errorResult('Invalid billing cycle months!', [
+                    'billing_cycle_months' => $params->billing_cycle_months,
+                    'allowed_billing_cycle_months' => [null, 1, 12, 24, 36]
+                ]);
+        }
+
         try {
             $companyId = null;
 
@@ -131,27 +152,10 @@ class Provider extends Category implements ProviderInterface
 
             $lineItem = [
                 'productId' => $productId,
-                'billingTerm' => 'Monthly',
+                'billingTerm' => $billingTerm,
                 'lineItemNumber' => 1,
                 'quantity' => 1,
             ];
-
-            if (isset($params->billing_cycle_months) && $params->billing_cycle_months > 1) {
-                switch ($params->billing_cycle_months) {
-                    case 12:
-                        $lineItem['billingTerm'] = 'Annual';
-                        break;
-                    case 24:
-                        $lineItem['billingTerm'] = '2-Year';
-                        break;
-                    case 36:
-                        $lineItem['billingTerm'] = '3-Year';
-                        break;
-                    default:
-                        $lineItem['billingTerm'] = 'Monthly';
-                        break;
-                }
-            }
 
             $dependency = $this->getProductDependencies($productId, $lineItem['billingTerm']);
             if ($dependency) {

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -1,0 +1,750 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\SoftwareLicenses\Providers\Pax8;
+
+use DateTime;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ServerException;
+use RuntimeException;
+use Throwable;
+use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
+use Upmind\ProvisionBase\Provider\DataSet\AboutData;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionProviders\SoftwareLicenses\Category;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\ChangePackageParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\ChangePackageResult;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\CreateParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\CreateResult;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\EmptyResult;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\GetUsageParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\GetUsageResult;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\ReissueParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\ReissueResult;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\RenewParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\RenewResult;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\SuspendParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\TerminateParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Data\UnsuspendParams;
+use Upmind\ProvisionProviders\SoftwareLicenses\Providers\Pax8\Data\Configuration;
+
+/**
+ * Pax8 provider.
+ */
+class Provider extends Category implements ProviderInterface
+{
+    protected Configuration $configuration;
+    protected Client|null $client = null;
+
+
+    protected string|null $token = null;
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function aboutProvider(): AboutData
+    {
+        return AboutData::create()
+            ->setName('Pax8 M365')
+            ->setLogoUrl('https://api.upmind.io/images/logos/provision/pax8-logo.png')
+            ->setDescription('Resell, provision and manage Pax8 M365 licenses');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function getUsageData(GetUsageParams $params): GetUsageResult
+    {
+        return GetUsageResult::create()
+            ->setUsageData($this->getSubscription($params->license_key));
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function create(CreateParams $params): CreateResult
+    {
+
+        if (!isset($params->package_identifier)) {
+            $this->errorResult('Package identifier is required!');
+        }
+
+        $productId = $this->getProductId($params->package_identifier);
+        if (!$productId) {
+            $productId = $this->getProductById($params->package_identifier);
+        }
+
+        if (!$productId) {
+            $this->errorResult('Cannot find package!');
+        }
+
+        try {
+            $companyId = null;
+
+            if (!empty($params->customer_name)) {
+                $companyId = $this->getCompanyByName($params->customer_name);
+            }
+
+            if (!$companyId && !empty($params->company_name)) {
+                $company = $this->getCompanyById($params->company_name);
+                if ($company) {
+                    $companyId = $params->company_name;
+                }
+            }
+
+            if (!$companyId) {
+                if (!(isset($params->extra['address']))) {
+                    $this->errorResult('Extra.address is required!');
+                }
+
+                $phone = $params->extra['phone'] ?? '00000000';
+
+                $address = $params->extra['address'];
+
+                $companyId = $this->createCompany($params->customer_name, $params->customer_email, $address, $params->customer_identifier, $phone);
+            }
+
+            $lineItem = [
+                'productId' => $productId,
+                'billingTerm' => 'Monthly',
+                'lineItemNumber' => 1,
+                'quantity' => 1,
+            ];
+
+            if (isset($params->billing_cycle_months) && $params->billing_cycle_months > 1) {
+                $lineItem['billingTerm'] = match ($params->billing_cycle_months) {
+                    12 => 'Annual',
+                    24 => '2-Year',
+                    36 => '3-Year',
+                    default => 'Monthly',
+                };
+            }
+
+            $dependency = $this->getProductDependencies($productId, $lineItem['billingTerm']);
+            if ($dependency) {
+                $lineItem['commitmentTermId'] = $dependency['id'];
+                $lineItem['billingTerm'] = $dependency['term'];
+            }
+
+            if ($lineItem['billingTerm'] == '1-Year') {
+                $lineItem['billingTerm'] = 'Annual';
+            }
+
+            $lineItem['provisioningDetails'] = $this->buildProvisioningDetails($params);;
+
+            $body = [
+                'companyId' => $companyId,
+                'orderedByUserEmail' => $params->customer_email,
+                'orderedBy' => 'Customer',
+                'lineItems' => [
+                    $lineItem,
+                ],
+            ];
+
+            $licenseId = null;
+            $response = $this->makeRequest('orders', ['isMock' => 'false'], $body);
+            foreach ($response['lineItems'] as $lineItem) {
+                if ($lineItem['productId'] == $productId) {
+                    $licenseId = $lineItem['subscriptionId'];
+                }
+            }
+
+            return CreateResult::create(['license_key' => (string)$licenseId])
+                ->setMessage('License created');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+
+    /**
+     * @param CreateParams $params
+     * @return array
+     */
+    function buildProvisioningDetails(CreateParams $params): array
+    {
+        $sharedDetails = $this->getSharedMicrosoftDetails();
+
+        if (isset($params->customer_identifier)) {
+            $details = $this->getExistingCustomerDetails($params->customer_identifier);
+        } else {
+            @[$firstName, $lastName] = explode(' ', $params->customer_name, 2);
+            $details = $this->getNewCustomerDetails($firstName, $lastName, $params->customer_email ?? '');
+        }
+
+        $details = array_merge($details, $sharedDetails);
+
+        return $this->formatProvisioningDetails($details);
+    }
+
+    /**
+     * @param string $firstName
+     * @param string $lastName
+     * @param string $email
+     * @return string[]
+     */
+    function getNewCustomerDetails(
+        string $firstName,
+        string $lastName,
+        string $email
+    ): array
+    {
+        return [
+            'msCustExists' => 'No, the customer does not have a Microsoft account',
+
+            'mca2020FirstName' => $firstName,
+            'mca2020LastName' => $lastName,
+            'mca2020Email' => $email,
+
+            'msftContactFirstName' => $firstName,
+            'msftContactLastName' => $lastName,
+            'msftContactEmail' => $email,
+        ];
+    }
+
+    /**
+     * @param string $tenantId
+     * @return string[]
+     */
+    function getExistingCustomerDetails(string $tenantId): array
+    {
+        return [
+            'msCustExists' => 'Yes, the customer has and can log into their Microsoft account',
+            'msTenantId' => $tenantId,
+
+            'mca2020FirstName' => '',
+            'mca2020LastName' => '',
+            'mca2020Email' => '',
+
+            'msftContactFirstName' => '',
+            'msftContactLastName' => '',
+            'msftContactEmail' => '',
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    function getSharedMicrosoftDetails(): array
+    {
+        return [
+            'microsoftCancelPolicyAcknowledgement' =>
+                'I understand, and acknowledge that I will have a 7 calendar day window to cancel my subscription, or make quantity decrements before I am no longer able to make these changes. Once a subscription is locked, I will be required fulfill my elected commitment term of my subscription.',
+            'microsoftTrialConversion' =>
+                'I understand and acknowledge that at the conclusion of my Microsoft trial license period (30 days), my 25 trial subscriptions will automatically convert to 25 paid subscriptions.'
+        ];
+    }
+
+
+    /**
+     * @param array $details
+     * @return array
+     */
+    function formatProvisioningDetails(array $details): array
+    {
+        return array_map(
+            fn($key, $value) => [
+                'key' => $key,
+                'values' => $value !== '' ? [$value] : [],
+            ],
+            array_keys($details),
+            $details
+        );
+    }
+
+    /**
+     * @param RenewParams $params
+     * @return RenewResult
+     * @throws Throwable
+     */
+    public function renew(RenewParams $params): RenewResult
+    {
+
+        $this->unsuspendSubscription($params->license_key);
+        return RenewResult::create()
+            ->setLicenseKey($params->license_key)
+            ->setPackageIdentifier($params->package_identifier)
+            ->setMessage('Renewal not required for Pax8 licenses');
+    }
+
+    /**
+     * Get license data by key.
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws ProvisionFunctionError
+     * @throws \Throwable
+     */
+    protected function getSubscription(string $license_key): ?array
+    {
+        try {
+            $response = $this->makeRequest("subscriptions/{$license_key}", null, null, 'GET');
+            return (array)$response;
+
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function changePackage(ChangePackageParams $params): ChangePackageResult
+    {
+        $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws ProvisionFunctionError
+     */
+    public function reissue(ReissueParams $params): ReissueResult
+    {
+        $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function suspend(SuspendParams $params): EmptyResult
+    {
+        if ($this->isLicenseInProgress($params->license_key)) {
+            return EmptyResult::create()->setMessage('Provisioning task in progress');
+        }
+
+        if ($this->isLicenseExpired($params->license_key)) {
+            return EmptyResult::create()->setMessage('License already suspended');
+        }
+
+        // All we can do is expire the license
+        return $this->cancelSubscription($params->license_key, 'License suspended');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function unsuspend(UnsuspendParams $params): EmptyResult
+    {
+        if ($this->isLicenseInProgress($params->license_key)) {
+            return EmptyResult::create()->setMessage('Provisioning task in progress');
+        }
+
+        if ($this->isLicenseActive($params->license_key)) {
+            return EmptyResult::create()->setMessage('License already active');
+        }
+
+        return $this->unsuspendSubscription($params->license_key);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function terminate(TerminateParams $params): EmptyResult
+    {
+        if ($this->isLicenseInProgress($params->license_key)) {
+            return EmptyResult::create()->setMessage('Provisioning task in progress');
+        }
+
+        if ($this->isLicenseExpired($params->license_key)) {
+            return EmptyResult::create()->setMessage('License already expired');
+        }
+
+        return $this->cancelSubscription($params->license_key);
+    }
+
+    protected function client(): Client
+    {
+        if (isset($this->client)) {
+            return $this->client;
+        }
+
+        $client = new Client([
+            'base_uri' => 'https://api.pax8.com',
+            'connect_timeout' => 10,
+            'headers' => [
+                'accept' => 'application/json',
+                'content-type' => 'application/json',
+            ],
+            'timeout' => 60,
+            'handler' => $this->getGuzzleHandlerStack(),
+        ]);
+
+        return $this->client = $client;
+    }
+
+    /**
+     * @throws ProvisionFunctionError
+     * @throws RuntimeException
+     */
+    private function getAuthToken(): string
+    {
+        $body = [
+            'client_id' => $this->configuration->clientId,
+            'client_secret' => $this->configuration->clientSecret,
+            'audience' => 'https://api.pax8.com',
+            'grant_type' => 'client_credentials',
+        ];
+
+        $response = $this->makeRequest('token', null, $body);
+
+        return $response['access_token'];
+    }
+
+    /**
+     * @return no-return
+     * @throws \Throwable
+     *
+     */
+    protected function handleException(Throwable $e): void
+    {
+        if (($e instanceof ClientException || $e instanceof ServerException) && $e->hasResponse()) {
+            /** @var \Psr\Http\Message\ResponseInterface $response */
+            $response = $e->getResponse();
+
+            $responseBody = $response->getBody()->__toString();
+            $responseData = json_decode($responseBody, true);
+
+            $errorMessage = $responseData['message'] ?? null;
+
+            $this->errorResult(
+                sprintf('Provider API Error: %s', $errorMessage),
+                ['response_data' => $responseData],
+                [],
+                $e
+            );
+        }
+
+        throw $e;
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws ProvisionFunctionError
+     */
+    public function makeRequest(string $command, ?array $params = null, ?array $body = null, ?string $method = 'POST'): ?array
+    {
+        $requestParams = [];
+
+        if ($params) {
+            $requestParams['query'] = $params;
+        }
+
+        if ($body) {
+            $requestParams['json'] = $body;
+        }
+
+        if ($command !== 'token') {
+            if (!$this->token) {
+                $this->token = $this->getAuthToken();
+            }
+
+            $requestParams['headers'] = [
+                'authorization' => 'Bearer ' . $this->token,
+            ];
+        }
+
+        $response = $this->client()->request($method, "/v1/{$command}", $requestParams);
+        $result = $response->getBody()->getContents();
+
+        $response->getBody()->close();
+
+        if ($result === '') {
+            return null;
+        }
+
+        return $this->parseResponseData($result);
+    }
+
+    /**
+     * @throws ProvisionFunctionError
+     */
+    private function parseResponseData(string $result): ?array
+    {
+        $parsedResult = json_decode($result, true);
+
+        if (!$parsedResult && $parsedResult != []) {
+            throw ProvisionFunctionError::create('Unknown Provider API Error')
+                ->withData([
+                    'response' => $result,
+                ]);
+        }
+
+        return $parsedResult;
+    }
+
+
+    /**
+     * Is a license active?
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws ProvisionFunctionError
+     * @throws \Throwable
+     */
+    private function isLicenseActive(string $licenseKey): bool
+    {
+        return in_array($this->getLicenseStatus($licenseKey), ['Active', 'Activated', 'PendingActivation']);
+    }
+
+    /**
+     * Is a license expired?
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws ProvisionFunctionError
+     * @throws \Throwable
+     */
+    private function isLicenseExpired(string $licenseKey): bool
+    {
+        return in_array($this->getLicenseStatus($licenseKey), ['Cancelled', 'PendingCancel']);
+    }
+
+    /**
+     * Is a license expired?
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws ProvisionFunctionError
+     * @throws \Throwable
+     */
+    private function isLicenseInProgress(string $licenseKey): bool
+    {
+        return in_array($this->getLicenseStatus($licenseKey), ['PendingManual', 'PendingAutomated']);
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws ProvisionFunctionError
+     * @throws \Throwable
+     */
+    private function getLicenseStatus(string $licenseKey): string
+    {
+        $licenseData = $this->getSubscription($licenseKey);
+        $status = $licenseData['status'] ?? null;
+
+        if ($status === null) {
+            $this->errorResult('Unable to determine license status');
+        }
+
+        return (string)$status;
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws ProvisionFunctionError
+     * @throws \Throwable
+     */
+    private function cancelSubscription(string $subscriptionId, string $message = 'License cancelled'): EmptyResult
+    {
+        try {
+            $this->makeRequest("subscriptions/{$subscriptionId}", null, null, 'DELETE');
+            return EmptyResult::create()->setMessage($message);
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws ProvisionFunctionError
+     * @throws \Throwable
+     */
+    private function unsuspendSubscription(string $subscriptionId, string $message = 'License unsuspended'): EmptyResult
+    {
+        $date = new DateTime('now');
+
+        $body = [
+            'startDate' => $date->format('Y-m-d\TH:i:s.v')
+        ];
+
+        try {
+            $this->makeRequest("subscriptions/{$subscriptionId}", null, $body, 'PUT');
+            return EmptyResult::create()->setMessage($message);
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @param string $customer
+     * @return string|null
+     */
+    private function getCompanyByName(string $customer): ?string
+    {
+        $query = [
+            'size' => 200,
+        ];
+
+        for ($page = 0; ; $page++) {
+            $query['page'] = $page;
+
+            $response = $this->makeRequest('companies', $query, null, 'GET');
+            if (!isset($response['content'])) {
+                return null;
+            }
+
+            foreach ($response['content'] as $company) {
+                if ($company['name'] === $customer) {
+                    return $company['id'];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $companyId
+     * @return array
+     */
+    private function getCompanyById(string $companyId): array
+    {
+        $response = $this->makeRequest("companies/{$companyId}", null, null, 'GET');
+        return (array)$response;
+    }
+
+    /**
+     * @param string $value
+     * @return string|null
+     */
+    private function getProductId(string $value): ?string
+    {
+        $query = [
+            'search' => $value,
+            'vendorName' => 'Microsoft',
+            'size' => 1,
+        ];
+
+        $response = $this->makeRequest('products', $query, null, 'GET');
+        if (!isset($response['content'])) {
+            return null;
+        }
+
+        return $response['content'][0]['id'];
+    }
+
+
+    /**
+     * @param string $package_identifier
+     * @return string|null
+     */
+    private function getProductById(string $package_identifier): ?string
+    {
+        return $this->makeRequest("products/{$package_identifier}", null, null, 'GET')['id'];
+    }
+
+    /**
+     * @param string $customer_name
+     * @param string $customer_email
+     * @param array $address
+     * @param string $website
+     * @param string $phone
+     * @return mixed
+     */
+    private function createCompany(string $customer_name, string $customer_email, array $address, string $website, string $phone): string
+    {
+        $body = [
+            'address' => $address,
+            'billOnBehalfOfEnabled' => false,
+            'selfServiceAllowed' => false,
+            'orderApprovalRequired' => false,
+            'name' => $customer_name,
+            'phone' => $phone,
+            'website' => $website,
+        ];
+
+        $response = $this->makeRequest('companies', null, $body);
+        $companyId = $response['id'];
+
+        $this->createContacts($customer_name, $customer_email, $companyId, $phone);
+
+        return (string)$companyId;
+    }
+
+    /**
+     * @param string $customer_name
+     * @param string $customer_email
+     * @param mixed $companyId
+     * @param string $phone
+     * @return void
+     */
+    private function createContacts(string $customer_name, string $customer_email, string $companyId, string $phone): void
+    {
+        @[$firstName, $lastName] = explode(' ', $customer_name, 2);
+
+
+        $contactBody = [
+            'firstName' => $firstName,
+            'lastName' => $lastName ?? $firstName,
+            'email' => $customer_email,
+            'phone' => $phone,
+            'types' => [
+                [
+                    'type' => 'Admin',
+                    'primary' => true,
+                ],
+                [
+                    'type' => 'Billing',
+                    'primary' => true,
+                ],
+                [
+                    'type' => 'Technical',
+                    'primary' => true,
+                ]
+            ]
+        ];
+
+        $this->makeRequest("companies/{$companyId}/contacts", null, $contactBody);
+    }
+
+    /**
+     * @param string $productId
+     * @param string $billingTerm
+     * @return array|null
+     */
+    private function getProductDependencies(string $productId, string $billingTerm): ?array
+    {
+
+        $response = $this->makeRequest("products/{$productId}/dependencies", null, null, 'GET');
+        if (!$response['commitmentDependencies']) {
+            return null;
+        }
+
+        foreach ($response['commitmentDependencies'] as $dependency) {
+            if ($dependency['term'] == $billingTerm) {
+                return $dependency;
+            }
+        }
+
+        return $response['commitmentDependencies'][0];
+    }
+}

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -7,6 +7,7 @@ namespace Upmind\ProvisionProviders\SoftwareLicenses\Providers\Pax8;
 use DateTime;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\ServerException;
 use RuntimeException;
 use Throwable;
@@ -36,10 +37,10 @@ use Upmind\ProvisionProviders\SoftwareLicenses\Providers\Pax8\Data\Configuration
 class Provider extends Category implements ProviderInterface
 {
     protected Configuration $configuration;
-    protected Client|null $client = null;
+    protected ?Client $client = null;
 
 
-    protected string|null $token = null;
+    protected ?string $token = null;
 
     public function __construct(Configuration $configuration)
     {
@@ -127,12 +128,20 @@ class Provider extends Category implements ProviderInterface
             ];
 
             if (isset($params->billing_cycle_months) && $params->billing_cycle_months > 1) {
-                $lineItem['billingTerm'] = match ($params->billing_cycle_months) {
-                    12 => 'Annual',
-                    24 => '2-Year',
-                    36 => '3-Year',
-                    default => 'Monthly',
-                };
+                switch ($params->billing_cycle_months) {
+                    case 12:
+                        $lineItem['billingTerm'] = 'Annual';
+                        break;
+                    case 24:
+                        $lineItem['billingTerm'] = '2-Year';
+                        break;
+                    case 36:
+                        $lineItem['billingTerm'] = '3-Year';
+                        break;
+                    default:
+                        $lineItem['billingTerm'] = 'Monthly';
+                        break;
+                }
             }
 
             $dependency = $this->getProductDependencies($productId, $lineItem['billingTerm']);
@@ -597,6 +606,7 @@ class Provider extends Category implements ProviderInterface
     /**
      * @param string $customer
      * @return string|null
+     * @throws GuzzleException
      */
     private function getCompanyByName(string $customer): ?string
     {
@@ -618,13 +628,12 @@ class Provider extends Category implements ProviderInterface
                 }
             }
         }
-
-        return null;
     }
 
     /**
      * @param string $companyId
      * @return array
+     * @throws GuzzleException
      */
     private function getCompanyById(string $companyId): array
     {
@@ -635,6 +644,7 @@ class Provider extends Category implements ProviderInterface
     /**
      * @param string $value
      * @return string|null
+     * @throws GuzzleException
      */
     private function getProductId(string $value): ?string
     {
@@ -656,6 +666,7 @@ class Provider extends Category implements ProviderInterface
     /**
      * @param string $package_identifier
      * @return string|null
+     * @throws GuzzleException
      */
     private function getProductById(string $package_identifier): ?string
     {
@@ -668,7 +679,8 @@ class Provider extends Category implements ProviderInterface
      * @param array $address
      * @param string $website
      * @param string $phone
-     * @return mixed
+     * @return string
+     * @throws GuzzleException
      */
     private function createCompany(string $customer_name, string $customer_email, array $address, string $website, string $phone): string
     {
@@ -693,18 +705,18 @@ class Provider extends Category implements ProviderInterface
     /**
      * @param string $customer_name
      * @param string $customer_email
-     * @param mixed $companyId
+     * @param string $companyId
      * @param string $phone
      * @return void
+     * @throws GuzzleException
      */
     private function createContacts(string $customer_name, string $customer_email, string $companyId, string $phone): void
     {
         @[$firstName, $lastName] = explode(' ', $customer_name, 2);
 
-
         $contactBody = [
             'firstName' => $firstName,
-            'lastName' => $lastName ?? $firstName,
+            'lastName' => $lastName != "" ? $lastName : $firstName,
             'email' => $customer_email,
             'phone' => $phone,
             'types' => [
@@ -730,6 +742,7 @@ class Provider extends Category implements ProviderInterface
      * @param string $productId
      * @param string $billingTerm
      * @return array|null
+     * @throws GuzzleException
      */
     private function getProductDependencies(string $productId, string $billingTerm): ?array
     {

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -83,8 +83,14 @@ class Provider extends Category implements ProviderInterface
         }
 
         $productId = $this->getProductId($params->package_identifier);
+
+        // If product not found by name or SKU, try by ID
         if (!$productId) {
-            $productId = $this->getProductById($params->package_identifier);
+            try {
+                $productId = $this->getProductById($params->package_identifier);
+            } catch (Throwable $e) {
+                $this->handleException($e);
+            }
         }
 
         if (!$productId) {
@@ -642,7 +648,9 @@ class Provider extends Category implements ProviderInterface
     }
 
     /**
-     * @param string $value
+     * Find a product by its name or SKU.
+     *
+     * @param string $value // Product name or SKU
      * @return string|null
      * @throws GuzzleException
      */
@@ -651,17 +659,30 @@ class Provider extends Category implements ProviderInterface
         $query = [
             'search' => $value,
             'vendorName' => 'Microsoft',
-            'size' => 1,
+            'size' => 10, // Sensible loop
         ];
 
         $response = $this->makeRequest('products', $query, null, 'GET');
+
         if (!isset($response['content'])) {
             return null;
         }
 
-        return $response['content'][0]['id'];
-    }
+        $lowerCaseValue = mb_strtolower($value);
 
+        // Try to match the product, first by name, then by SKU
+        foreach ($response['content'] as $product) {
+            if (isset($product['name']) && mb_strtolower($product['name']) === $lowerCaseValue) {
+                return $product['id'];
+            }
+
+            if (isset($product['sku']) && mb_strtolower($product['sku']) === $lowerCaseValue) {
+                return $product['id'];
+            }
+        }
+
+        return null;
+    }
 
     /**
      * @param string $package_identifier
@@ -670,7 +691,18 @@ class Provider extends Category implements ProviderInterface
      */
     private function getProductById(string $package_identifier): ?string
     {
-        return $this->makeRequest("products/{$package_identifier}", null, null, 'GET')['id'];
+        try {
+            $product = $this->makeRequest("products/{$package_identifier}", null, null, 'GET');
+
+            return $product['id'] ?? null;
+        } catch (ClientException $e) {
+            // Not found
+            if ($e->getResponse()->getStatusCode() === 404) {
+                return null;
+            }
+
+            throw $e;
+        }
     }
 
     /**

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -229,19 +229,24 @@ class Provider extends Category implements ProviderInterface
      */
     public function renew(RenewParams $params): RenewResult
     {
-        try {
-            $this->unsuspend(UnsuspendParams::create([
-                'license_key' => $params->license_key,
-                'customer_identifier' => $params->customer_identifier,
-            ]));
-        } catch (ProvisionFunctionError $e) {
-            $this->errorResult('License cannot be unsuspended for renewal', [], [], $e);
+        if ($this->isLicenseActive($params->license_key)) {
+            return RenewResult::create()
+                ->setLicenseKey($params->license_key)
+                ->setPackageIdentifier($params->package_identifier)
+                ->setMessage('License is active, renewal not required');
         }
+
+        if ($this->isLicenseInProgress($params->license_key)) {
+            $this->errorResult('License cannot be renewed while a Provisioning task is in progress');
+        }
+
+        // Other states mean expired, so we can just unsuspend it.
+        $this->unsuspendSubscription($params->license_key);
 
         return RenewResult::create()
             ->setLicenseKey($params->license_key)
             ->setPackageIdentifier($params->package_identifier)
-            ->setMessage('License is active, renewal not required');
+            ->setMessage('License was expired, unsuspended for renewal');
     }
 
     /**

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -230,7 +230,7 @@ class Provider extends Category implements ProviderInterface
     public function suspend(SuspendParams $params): EmptyResult
     {
         if ($this->isLicenseInProgress($params->license_key)) {
-            return EmptyResult::create()->setMessage('Provisioning task in progress');
+            $this->errorResult('License cannot be suspended while a Provisioning task is in progress');
         }
 
         if ($this->isLicenseExpired($params->license_key)) {
@@ -251,7 +251,7 @@ class Provider extends Category implements ProviderInterface
     public function unsuspend(UnsuspendParams $params): EmptyResult
     {
         if ($this->isLicenseInProgress($params->license_key)) {
-            return EmptyResult::create()->setMessage('Provisioning task in progress');
+            $this->errorResult('License cannot be suspended while a Provisioning task is in progress');
         }
 
         if ($this->isLicenseActive($params->license_key)) {
@@ -271,7 +271,7 @@ class Provider extends Category implements ProviderInterface
     public function terminate(TerminateParams $params): EmptyResult
     {
         if ($this->isLicenseInProgress($params->license_key)) {
-            return EmptyResult::create()->setMessage('Provisioning task in progress');
+            $this->errorResult('License cannot be terminated while a Provisioning task is in progress');
         }
 
         if ($this->isLicenseExpired($params->license_key)) {

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -731,7 +731,14 @@ class Provider extends Category implements ProviderInterface
         string $phone
     ): string {
         $body = [
-            'address' => $address,
+            'address' => [
+                'street' => $address->address_1,
+                'street2' => $address->address_2 ?? '',
+                'city' => $address->city,
+                'stateOrProvince' => $address->state,
+                'postalCode' => $address->postcode,
+                'country' => $address->country_code
+            ],
             'billOnBehalfOfEnabled' => false,
             'selfServiceAllowed' => false,
             'orderApprovalRequired' => false,

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -234,12 +234,19 @@ class Provider extends Category implements ProviderInterface
      */
     public function renew(RenewParams $params): RenewResult
     {
+        try {
+            $this->unsuspend(UnsuspendParams::create([
+                'license_key' => $params->license_key,
+                'customer_identifier' => $params->customer_identifier,
+            ]));
+        } catch (ProvisionFunctionError $e) {
+            $this->errorResult('License cannot be unsuspended for renewal', [], [], $e);
+        }
 
-        $this->unsuspendSubscription($params->license_key);
         return RenewResult::create()
             ->setLicenseKey($params->license_key)
             ->setPackageIdentifier($params->package_identifier)
-            ->setMessage('Renewal not required for Pax8 licenses');
+            ->setMessage('License is active, renewal not required');
     }
 
     /**
@@ -630,7 +637,7 @@ class Provider extends Category implements ProviderInterface
      */
     private function unsuspendSubscription(string $subscriptionId, string $message = 'License unsuspended'): EmptyResult
     {
-        $date = new DateTime('now');
+        $date = new DateTime('now', 'UTC');
 
         $body = [
             'startDate' => $date->format('Y-m-d\TH:i:s.v')

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -198,8 +198,8 @@ class Provider extends Category implements ProviderInterface
             $response = $this->makeRequest('orders', ['isMock' => 'false'], $body);
 
             foreach ($response['lineItems'] as $lineItem) {
-                if ((string) $lineItem['productId'] === $productId) {
-                    $licenseId = $lineItem['subscriptionId'];
+                if (isset($lineItem['productId']) && (string) $lineItem['productId'] === $productId) {
+                    $licenseId = $lineItem['subscriptionId'] ?? null;
                 }
             }
 

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -541,7 +541,6 @@ class Provider extends Category implements ProviderInterface
         }
     }
 
-
     /**
      * Is a license active?
      *

--- a/src/Providers/Pax8/Provider.php
+++ b/src/Providers/Pax8/Provider.php
@@ -38,7 +38,6 @@ class Provider extends Category implements ProviderInterface
 {
     protected Configuration $configuration;
     protected ?Client $client = null;
-
     protected ?string $token = null;
 
     public function __construct(Configuration $configuration)
@@ -79,7 +78,6 @@ class Provider extends Category implements ProviderInterface
      */
     public function create(CreateParams $params): CreateResult
     {
-
         if (!isset($params->package_identifier)) {
             $this->errorResult('Package identifier is required!');
         }
@@ -116,7 +114,13 @@ class Provider extends Category implements ProviderInterface
 
                 $address = $params->extra['address'];
 
-                $companyId = $this->createCompany($params->customer_name, $params->customer_email, $address, $params->customer_identifier, $phone);
+                $companyId = $this->createCompany(
+                    $params->customer_name,
+                    $params->customer_email,
+                    $address,
+                    $params->customer_identifier,
+                    $phone
+                );
             }
 
             $lineItem = [
@@ -153,7 +157,7 @@ class Provider extends Category implements ProviderInterface
                 $lineItem['billingTerm'] = 'Annual';
             }
 
-            $lineItem['provisioningDetails'] = $this->buildProvisioningDetails($params);;
+            $lineItem['provisioningDetails'] = $this->buildProvisioningDetails($params);
 
             $body = [
                 'companyId' => $companyId,
@@ -670,16 +674,15 @@ class Provider extends Category implements ProviderInterface
     }
 
     /**
-     * @param string $customer_name
-     * @param string $customer_email
-     * @param array $address
-     * @param string $website
-     * @param string $phone
-     * @return string
      * @throws GuzzleException
      */
-    private function createCompany(string $customer_name, string $customer_email, array $address, string $website, string $phone): string
-    {
+    private function createCompany(
+        string $customer_name,
+        string $customer_email,
+        array $address,
+        string $website,
+        string $phone
+    ): string {
         $body = [
             'address' => $address,
             'billOnBehalfOfEnabled' => false,


### PR DESCRIPTION
Follow up from #25 

Add Pax8 M365 provider integration

- Added `customer_address` & `customer_phone` to `CreateParams`

The following operations are implemented for Pax8:
- getUsageData()
- create() - If the company account does not exist, create using the `customer_address`. Example: 

```
"address": {
    "street": "5500 S Quebec St",
    "street2": "Ste. 350",
    "city": "Greenwood Village",
    "stateOrProvince": "CO",
    "postalCode": "80111",
    "country": "US"
  }
```

- suspend()
- terminate()
- unsuspend() - this one is implemented according to the docs but the call always results in a `Pending` status, and the subscription cannot be successfully unsuspended.
- renew() - there is no official "renew" process, license is active until cancelled, so we just activate it again if cancelled.

The following operations aren't supported:

- changePackage()
- reissue()